### PR TITLE
Add Configh.add_cppflag and Configh.remove_cppflag methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,39 +1,17 @@
 name: test
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+
 
 jobs:
   luacheck:
     runs-on: ubuntu-latest
-    steps:
-    -
-      name: Checkout
-      uses: actions/checkout@v2
-    -
-      name: Setup Lua
-      uses: leafo/gh-actions-lua@v10
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
-    -
-      name: Install Tools
-      run: luarocks install luacheck
-    -
-      name: Run luacheck
-      run: |
-        luacheck .
-
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        lua-version:
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
-          - "luajit-2.0.5"
-          - "luajit-openresty"
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     steps:
     -
       name: Checkout
@@ -41,13 +19,36 @@ jobs:
       with:
         submodules: 'true'
     -
-      name: Setup Lua ${{ matrix.lua-version }}
-      uses: leafo/gh-actions-lua@v10
-      with:
-        luaVersion: ${{ matrix.lua-version }}
+      name: Install Tools
+      run: luarocks install luacheck
     -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
+      name: Run luacheck
+      run: |
+        luacheck --no-self .
+
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
+    strategy:
+      matrix:
+        lua-version:
+          - "5.1.:latest"
+          - "5.2.:latest"
+          - "5.3.:latest"
+          - "5.4.:latest"
+          - "lj-v2.1:latest"
+    steps:
+    -
+      name: Switch Lua Version
+      run: |
+        lenv -g use ${{ matrix.lua-version }}
+        lua -v || true
+    -
+      name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     -
       name: Install
       run: |
@@ -64,6 +65,8 @@ jobs:
         testcase ./test/
     -
       name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
+        files: ./luacov.report.out

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ local cfgh = configh('gcc')
 -- set feature macro
 cfgh:set_feature('_GNU_SOURCE')
 
+-- add cppflags
+-- CPPFLAGS environment variable is also loaded automatically
+cfgh:add_cppflag('-I/usr/local/include')
+
 -- check whether the specified header file exists or not.
 local ok, err = cfgh:check_header('stdio.h')
 if not ok then
@@ -108,6 +112,29 @@ remove a feature macro that set by `configh:set_feature` method.
 
 - `name:string`: a feature macro name.
 - `value:string?`: a feature macro value.
+
+
+## configh:add_cppflag( flag )
+
+add a cppflag to be used when compiling test code.
+
+**Parameters**
+
+- `flag:string`: a cppflag string (e.g. `-I/usr/local/include`, `-DDEBUG`).
+
+**NOTE**
+
+- The `CPPFLAGS` environment variable is automatically loaded when creating a `configh` object.
+- Tilde (`~`) is **not** expanded. Use `$HOME` or absolute path instead (e.g. `-I$HOME/include` or `-I/home/user/include`).
+
+
+## configh:remove_cppflag( flag )
+
+remove a cppflag that was added by `configh:add_cppflag` method.
+
+**Parameters**
+
+- `flag:string`: a cppflag string.
 
 
 ## configh:output_status( enabled )

--- a/lib/configh.lua
+++ b/lib/configh.lua
@@ -119,6 +119,18 @@ function Configh:unset_feature(name)
     self.exec:unset_feature(name)
 end
 
+--- add_cppflag add a cppflag
+--- @param flag string
+function Configh:add_cppflag(flag)
+    self.exec:add_cppflag(flag)
+end
+
+--- remove_cppflag remove a cppflag
+--- @param flag string
+function Configh:remove_cppflag(flag)
+    self.exec:remove_cppflag(flag)
+end
+
 local DECL_NAME_FORMAT = {
     header = '<%s>',
     ['function'] = "`%s'",

--- a/test/configh_test.lua
+++ b/test/configh_test.lua
@@ -153,6 +153,26 @@ function testcase.output_status()
     assert.match(table.concat(data), 'check header: stdio.h ... found')
 end
 
+function testcase.add_and_remove_cppflag()
+    local cfgh = configh('gcc')
+
+    -- test that add cppflag
+    cfgh:add_cppflag('-I/usr/local/include')
+    assert.is_uint(cfgh.exec.cppflags['-I/usr/local/include'])
+    assert.equal(cfgh.exec.cppflags[cfgh.exec.cppflags['-I/usr/local/include']],
+                 '-I/usr/local/include')
+
+    -- test that add multiple cppflags
+    cfgh:add_cppflag('-I/opt/include')
+    cfgh:add_cppflag('-DDEBUG')
+    assert.equal(#cfgh.exec.cppflags, 3)
+
+    -- test that remove cppflag
+    cfgh:remove_cppflag('-I/usr/local/include')
+    assert.is_nil(cfgh.exec.cppflags['-I/usr/local/include'])
+    assert.equal(#cfgh.exec.cppflags, 2)
+end
+
 function testcase.flush()
     local cfgh = configh('gcc')
     assert(cfgh:check_header('stdio.h'))

--- a/test/executor_test.lua
+++ b/test/executor_test.lua
@@ -167,3 +167,53 @@ function testcase.check_member()
     assert.match(err, 'member must be a string')
 end
 
+function testcase.add_and_remove_cppflag()
+    local exec = executor('gcc')
+
+    -- test that add cppflag
+    exec:add_cppflag('-I/usr/local/include')
+    assert.is_uint(exec.cppflags['-I/usr/local/include'])
+    assert.equal(exec.cppflags[exec.cppflags['-I/usr/local/include']],
+                 '-I/usr/local/include')
+
+    -- test that add multiple cppflags
+    exec:add_cppflag('-I/opt/include')
+    exec:add_cppflag('-DDEBUG')
+    assert.equal(#exec.cppflags, 3)
+
+    -- test that do not add duplicate cppflag
+    exec:add_cppflag('-I/usr/local/include')
+    assert.equal(#exec.cppflags, 3)
+
+    -- test that remove cppflag
+    exec:remove_cppflag('-I/usr/local/include')
+    assert.is_nil(exec.cppflags['-I/usr/local/include'])
+    assert.equal(#exec.cppflags, 2)
+
+    -- test that remove non-existent cppflag does not throw error
+    exec:remove_cppflag('-I/nonexistent')
+    assert.equal(#exec.cppflags, 2)
+
+    -- test that throws an error if flag argument is not string
+    local err = assert.throws(exec.add_cppflag, exec, 123)
+    assert.match(err, 'flag must be string')
+    err = assert.throws(exec.remove_cppflag, exec, 123)
+    assert.match(err, 'flag must be string')
+end
+
+function testcase.cppflags_env()
+    -- test that load CPPFLAGS environment variable
+    setenv('CPPFLAGS', '-I/usr/local/include -DDEBUG')
+    local exec = executor('gcc')
+    assert.is_uint(exec.cppflags['-I/usr/local/include'])
+    assert.is_uint(exec.cppflags['-DDEBUG'])
+    assert.equal(#exec.cppflags, 2)
+    setenv('CPPFLAGS', nil)
+
+    -- test that CPPFLAGS environment variable is empty
+    setenv('CPPFLAGS', '')
+    exec = executor('gcc')
+    assert.equal(#exec.cppflags, 0)
+    setenv('CPPFLAGS', nil)
+end
+


### PR DESCRIPTION
This pull request adds support for managing C preprocessor flags (cppflags) in the `configh` library, allowing users to specify and remove custom flags for compilation tests. The changes also ensure that cppflags from the `CPPFLAGS` environment variable are automatically loaded. Comprehensive tests and documentation updates are included to cover the new functionality.

### Feature additions

* Added `add_cppflag` and `remove_cppflag` methods to both the `Configh` and `Executor` classes, enabling users to add or remove cppflags used during compilation checks. [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R122-R133) [[2]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3R207-R229)
* Automatically loads cppflags from the `CPPFLAGS` environment variable when creating an `Executor` instance, ensuring environment-based flags are respected.

### Build process integration

* Updated the compilation command in `Executor` to include all active cppflags, ensuring they are used in test builds.

### Documentation

* Added documentation for the new `add_cppflag` and `remove_cppflag` methods, including usage notes and parameter details in `README.md`.
* Provided an example in `README.md` demonstrating how to use the new cppflag functionality.

### Testing

* Added and extended tests to verify adding, removing, and loading cppflags, including edge cases and error handling in both `configh_test.lua` and `executor_test.lua`. [[1]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748R156-R175) [[2]](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0R170-R219)

### Internal structure

* Updated the `Executor` class to include a new `cppflags` field for managing the collection of cppflags.