### PR TITLE
Add Configh.check_decl method

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ remove a cppflag that was added by `configh:add_cppflag` method.
 
 ## configh:output_status( enabled )
 
-enables or disables the output of status messages to stdout when the `configh:check_header`, `configh:check_func`, `configh:check_type`, `configh:check_member` methods are called.
+enables or disables the output of status messages to stdout when the `configh:check_header`, `configh:check_func`, `configh:check_type`, `configh:check_decl`, `configh:check_member` methods are called.
 
 **Parameters**
 
@@ -183,6 +183,21 @@ checks whether the specified type exists or not.
 
 - `headers:string|string[]`: a header file name or array of header file names.
 - `type:string`: a type name.
+
+**Returns**
+
+- `ok:boolean`: `true` on success, or `false` on failure.
+- `err:string`: error message if the generated source code fails to compile.
+
+
+## ok, err = configh:check_decl( headers, name )
+
+checks whether the specified declaration (macro constant, enum value, or global variable) exists or not.
+
+**Parameters**
+
+- `headers:string|string[]`: a header file name or array of header file names.
+- `name:string`: a declaration name.
 
 **Returns**
 

--- a/lib/configh.lua
+++ b/lib/configh.lua
@@ -135,6 +135,7 @@ local DECL_NAME_FORMAT = {
     header = '<%s>',
     ['function'] = "`%s'",
     type = "`%s'",
+    decl = "`%s'",
     member = "`%s'",
 }
 
@@ -144,6 +145,7 @@ local DECL_NAME_FORMAT = {
 --- | 'header'
 --- | 'function'
 --- | 'type'
+--- | 'decl'
 --- | 'member'
 --- @param name string
 --- @param is_exists boolean
@@ -171,6 +173,7 @@ local DECL_METHOD = {
     header = 'check_header',
     ['function'] = 'check_func',
     type = 'check_type',
+    decl = 'check_decl',
     member = 'check_member',
 }
 
@@ -180,6 +183,7 @@ local DECL_METHOD = {
 --- | 'header'
 --- | 'function'
 --- | 'type'
+--- | 'decl'
 --- | 'member'
 --- @param params table<string, string>|table<'headers', string[]>
 --- @return boolean ok
@@ -256,6 +260,20 @@ function Configh:check_type(headers, ctype)
         defname = ctype,
         headers = headers,
         type = ctype,
+    })
+end
+
+--- check_decl check whether named symbol is defined as a macro or can be used as an r-value
+--- @param headers string|string[]
+--- @param name string
+--- @return boolean ok true if the type exists
+--- @return string? err error for compile the generated source file
+--- @return string? errerr error for failed to define macro
+function Configh:check_decl(headers, name)
+    return check(self, 'decl', {
+        defname = name,
+        headers = headers,
+        decl = name,
     })
 end
 

--- a/lib/executor.lua
+++ b/lib/executor.lua
@@ -259,6 +259,21 @@ function Executor:check_type(headers, ctype)
     return compile(self, self:makecsrc(headers, format('%s x', ctype)))
 end
 
+--- check_decl check whether named symbol is defined as a macro or can be used as an r-value
+--- @param headers string|string[]
+--- @param name string
+--- @return boolean ok
+--- @return string? err
+function Executor:check_decl(headers, name)
+    assert(type(name) == 'string', 'name must be a string')
+    return compile(self, self:makecsrc(headers, format([[
+#ifndef %s
+    (void)%s;
+#endif
+
+]], name, name)))
+end
+
 --- check_member check the member field is available
 --- @param headers string|string[]
 --- @param ctype string

--- a/test/configh_test.lua
+++ b/test/configh_test.lua
@@ -1,5 +1,6 @@
 require('luacov')
 local testcase = require('testcase')
+local assert = require('assert')
 local setenv = require('setenv')
 local configh = require('configh')
 
@@ -127,6 +128,25 @@ function testcase.check_member()
     assert.is_string(err)
     assert.re_match(table.concat(cfgh.macros, '\n'),
                     '^/\\* #undef HAVE_STRUCT_SOCKADDR_UNKNOWN_MEMBER \\*/', 'm')
+end
+
+function testcase.check_decl()
+    local cfgh = configh('gcc')
+
+    -- test that check whether the macro constant is defined
+    local ok, err = cfgh:check_decl('limits.h', 'PATH_MAX')
+    assert(ok, err)
+    -- confirm that the macro is defined in macro list
+    assert.re_match(table.concat(cfgh.macros, '\n'), '^#define HAVE_PATH_MAX 1',
+                    'm')
+
+    -- test that add commented macro if the declaration is not available
+    ok, err = cfgh:check_decl('limits.h', 'UNKNOWN_CONSTANT')
+    assert.is_false(ok)
+    assert.is_string(err)
+
+    assert.re_match(table.concat(cfgh.macros, '\n'),
+                    '^/\\* #undef HAVE_UNKNOWN_CONSTANT \\*/', 'm')
 end
 
 function testcase.output_status()

--- a/test/executor_test.lua
+++ b/test/executor_test.lua
@@ -1,5 +1,6 @@
 require('luacov')
 local testcase = require('testcase')
+local assert = require('assert')
 local setenv = require('setenv')
 local executor = require('configh.executor')
 
@@ -199,6 +200,34 @@ function testcase.add_and_remove_cppflag()
     assert.match(err, 'flag must be string')
     err = assert.throws(exec.remove_cppflag, exec, 123)
     assert.match(err, 'flag must be string')
+end
+
+function testcase.check_decl()
+    local exec = executor('gcc')
+
+    -- test that check whether the macro constant is defined
+    local ok, err = exec:check_decl('limits.h', 'PATH_MAX')
+    assert.is_true(ok)
+    assert.is_nil(err)
+
+    -- test that check whether the enum value is defined
+    ok, err = exec:check_decl('fcntl.h', 'O_RDONLY')
+    assert.is_true(ok)
+    assert.is_nil(err)
+
+    -- test that check whether the global variable is defined
+    ok, err = exec:check_decl('errno.h', 'errno')
+    assert.is_true(ok)
+    assert.is_nil(err)
+
+    -- test that return false if the declaration is not available
+    ok, err = exec:check_decl('limits.h', 'UNKNOWN_CONSTANT')
+    assert.is_false(ok)
+    assert.is_string(err)
+
+    -- test that throws an error if name argument is not string
+    err = assert.throws(exec.check_decl, exec, 'stdio.h', 123)
+    assert.match(err, 'name must be a string')
 end
 
 function testcase.cppflags_env()


### PR DESCRIPTION
This pull request introduces a new `check_decl` method to both the `Configh` and `Executor` classes, allowing the system to check for the existence of macro constants, enum values, or global variables in C header files. The changes are documented in the `README.md`, and comprehensive tests have been added to ensure correct functionality and error handling. This enhancement improves the configurability and robustness of the library by enabling detection of a broader range of C declarations.

### Feature Addition: Declaration Existence Checking

* Added `check_decl` method to `Configh` and `Executor` classes, enabling checks for the existence of macro constants, enum values, or global variables in specified headers. [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R266-R279) [[2]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3R262-R276)
* Updated internal tables (`DECL_NAME_FORMAT` and `DECL_METHOD`) to support the new `decl` type for formatting and method dispatch. [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R138) [[2]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R148) [[3]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R176) [[4]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R186)

### Documentation

* Updated `README.md` to document the new `check_decl` method, including its parameters, return values, and usage. Also updated status message documentation to include `check_decl`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R142) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R193-R207)

### Testing

* Added unit tests for `check_decl` in both `configh_test.lua` and `executor_test.lua`, covering successful checks, failure cases, and argument validation. [[1]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748R133-R151) [[2]](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0R205-R232)
* Required the `assert` module in test files to support new assertions. [[1]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748R3) [[2]](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0R3)