### PR TITLE
Add Configh.set_stdout method

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ enables or disables the output of status messages to stdout when the `configh:ch
 - `enabled:boolean`: `true` to enable, or `false` to disable.
 
 
+## configh:set_stdout( [outfile] )
+
+sets the output file for status messages when the `configh:check_header`, `configh:check_func`, `configh:check_type`, `configh:check_decl`, `configh:check_member` methods are called.
+
+**Parameters**
+
+- `outfile:file*?`: an output file handle. If `nil` or omitted, `io.stdout` is used.
+
+
 ## ok, err = configh:check_header( header )
 
 checks whether the specified header file exists or not.

--- a/lib/configh.lua
+++ b/lib/configh.lua
@@ -27,12 +27,18 @@ local open = io.open
 local date = os.date
 local remove = os.remove
 local vformat = require('print').format
+local isfile = require('io.isfile')
 local executor = require('configh.executor')
+
+-- disable output buffering as default
+local STDOUT = io.stdout
+STDOUT:setvbuf('no')
 
 --- @class configh
 --- @field macros string[]
 --- @field exec configh.executor
 --- @field output boolean
+--- @field outfile file*
 local Configh = {}
 
 --- new create a new configh object
@@ -44,6 +50,7 @@ function Configh:init(cc)
     }
     self.exec = executor(cc)
     self.output = false
+    self.outfile = STDOUT
 
     return self
 end
@@ -53,7 +60,13 @@ end
 function Configh:output_status(enabled)
     assert(type(enabled) == 'boolean', 'enabled must be boolean')
     self.output = enabled
-    io.stdout:setvbuf('no')
+end
+
+--- set_stdout set the output file for status messages
+--- @param outfile file*?
+function Configh:set_stdout(outfile)
+    assert(outfile == nil or isfile(outfile), 'outfile must be file or nil')
+    self.outfile = outfile or STDOUT
 end
 
 --- printf output the message to stdout
@@ -62,7 +75,7 @@ end
 --- @param ... any
 local function printf(self, fmt, ...)
     if self.output then
-        io.stdout:write(vformat(fmt, ...))
+        self.outfile:write(vformat(fmt, ...))
     end
 end
 

--- a/rockspecs/configh-dev-1.rockspec
+++ b/rockspecs/configh-dev-1.rockspec
@@ -14,6 +14,7 @@ dependencies = {
     "gcfn >= 0.3.0",
     "metamodule >= 0.4.1",
     "io-truncate >= 0.1.0",
+    "io-isfile >= 0.1.0",
     "print >= 0.3.0",
 }
 build = {

--- a/test/configh_test.lua
+++ b/test/configh_test.lua
@@ -151,26 +151,15 @@ end
 
 function testcase.output_status()
     local cfgh = configh('gcc')
+    local stdout = assert(io.tmpfile())
+    stdout:setvbuf('no')
+    cfgh:set_stdout(stdout)
 
     -- test that enable output status
     cfgh:output_status(true)
-    local stdout = io.stdout
-    local data = {}
-    -- luacheck: ignore 122
-    io.stdout = {
-        setvbuf = function()
-        end,
-        write = function(_, ...)
-            for _, v in ipairs({
-                ...,
-            }) do
-                data[#data + 1] = v
-            end
-        end,
-    }
     cfgh:check_header('stdio.h')
-    io.stdout = stdout
-    assert.match(table.concat(data), 'check header: stdio.h ... found')
+    stdout:seek('set')
+    assert.match(stdout:read('*a'), 'check header: stdio.h ... found')
 end
 
 function testcase.add_and_remove_cppflag()


### PR DESCRIPTION
This pull request improves the way output is managed in the `configh` module by introducing support for configurable output streams, making it easier to redirect status messages and improving testability. The main changes include adding an `outfile` field to the `Configh` class, supporting custom output files, and updating tests to use temporary files instead of monkey-patching `io.stdout`.

**Output stream management improvements:**

* Added an `outfile` field to the `Configh` class, defaulting to `io.stdout`, and a new `set_stdout` method to allow configurable output streams for status messages. This makes it possible to redirect output easily for different use cases. [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R30-R41) [[2]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R53) [[3]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L56-R73)
* Updated the `printf` function to write status messages to `self.outfile` instead of directly to `io.stdout`.
* Disabled output buffering by default on `io.stdout` to ensure immediate output.

**Testing improvements:**

* Refactored the `output_status` test to use a temporary file for capturing output, leveraging the new `set_stdout` method, and removed the previous monkey-patching of `io.stdout`.

**Dependency updates:**

* Added `io-isfile` as a dependency to support output file type checking.