### PR TITLE
Change Executor.set_feature to accept number value

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ defines a feature macro in generated source code.
 **Parameters**
 
 - `name:string`: a feature macro name.
-- `value:string?`: a feature macro value.
+- `value:string|number?`: a feature macro value.
 
 
 ## configh:unset_feature( name )
@@ -111,7 +111,6 @@ remove a feature macro that set by `configh:set_feature` method.
 **Parameters**
 
 - `name:string`: a feature macro name.
-- `value:string?`: a feature macro value.
 
 
 ## configh:add_cppflag( flag )

--- a/lib/executor.lua
+++ b/lib/executor.lua
@@ -176,11 +176,17 @@ end
 
 --- set_feature define the feature macro in testing
 --- @param name string
---- @param value? string
+--- @param value? string|number
 function Executor:set_feature(name, value)
+    local tv = type(value)
     assert(type(name) == 'string', 'name must be string')
-    assert(type(value) == 'string' or value == nil,
-           'value must be string or nil')
+    assert(value == nil or tv == 'string' or tv == 'number',
+           'value must be a string, number or nil')
+
+    -- convert number to string
+    if tv == 'number' then
+        value = tostring(value)
+    end
 
     local feature = concat({
         '#define',

--- a/test/executor_test.lua
+++ b/test/executor_test.lua
@@ -61,25 +61,27 @@ function testcase.set_and_unset_featrue()
     assert.is_uint(exec.features._GNU_SOURCE)
     assert.equal(exec.features[exec.features._GNU_SOURCE], '#define _GNU_SOURCE')
 
-    -- test that replace new feature macro
-    exec:set_feature('_GNU_SOURCE', '123')
+    -- test that replace new feature macro with number value
+    exec:set_feature('_GNU_SOURCE', 123)
     assert.is_uint(exec.features._GNU_SOURCE)
     assert.equal(exec.features[exec.features._GNU_SOURCE],
                  '#define _GNU_SOURCE 123')
+
+    -- test that replace new feature macro with string value
+    exec:set_feature('_GNU_SOURCE', '"foo"')
+    assert.is_uint(exec.features._GNU_SOURCE)
+    assert.equal(exec.features[exec.features._GNU_SOURCE],
+                 '#define _GNU_SOURCE "foo"')
 
     -- test that remove feature macro
     exec:unset_feature('_GNU_SOURCE')
     assert.is_nil(exec.features._GNU_SOURCE)
 
-    -- test that throws an error if name argument is not string
-    local err = assert.throws(exec.set_feature, exec, 123)
+    -- test that throws an error if name argument is nether nil, string nor number
+    local err = assert.throws(exec.set_feature, exec, {})
     assert.match(err, 'name must be string')
-    err = assert.throws(exec.unset_feature, exec, 123)
+    err = assert.throws(exec.unset_feature, exec, {})
     assert.match(err, 'name must be string')
-
-    -- test that throws an error if value argument is not string
-    err = assert.throws(exec.set_feature, exec, '_GNU_SOURCE', 123)
-    assert.match(err, 'value must be string or nil')
 end
 
 function testcase.check_header()


### PR DESCRIPTION
This pull request updates the handling of feature macro values to allow both strings and numbers, improves type validation, and enhances the related documentation and tests. The primary focus is on making the `set_feature` method more flexible and robust.

**Feature macro value type support:**

* Updated the `Executor:set_feature` method in `lib/executor.lua` to accept both string and number types for the `value` parameter, converting numbers to strings as needed and improving type assertions.

**Documentation improvements:**

* Modified the documentation in `README.md` to specify that the `value` parameter for defining a feature macro can now be a string or number, and removed the unused `value` parameter from the unset feature macro section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L104-R104) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114)

**Test enhancements:**

* Updated `test/executor_test.lua` to test setting feature macros with both string and number values, and improved error handling tests for invalid argument types.