### PR TITLE
Replace add_cppflag/remove_cppflag with set_cppflags and add_cppflags

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ cfgh:set_feature('_GNU_SOURCE')
 
 -- add cppflags
 -- CPPFLAGS environment variable is also loaded automatically
-cfgh:add_cppflag('-I/usr/local/include')
+cfgh:add_cppflags({'-I/usr/local/include', '-DDEBUG'})
 
 -- check whether the specified header file exists
 local ok, err = cfgh:check_header('stdio.h')
@@ -321,27 +321,31 @@ Removes a feature macro that was set by the `configh:set_feature` method.
 - `name:string`: a feature macro name.
 
 
-## configh:add_cppflag( flag )
+## configh:set_cppflags( flags )
 
-Adds a cppflag to be used when compiling test code.
+Sets the cppflags to be used when compiling test code. Replaces any previously set cppflags, including those loaded from the `CPPFLAGS` environment variable.
 
 **Parameters**
 
-- `flag:string`: a cppflag string (e.g. `-I/usr/local/include`, `-DDEBUG`).
+- `flags:string|string[]`: a cppflag string or an array of cppflag strings (e.g. `'-I/usr/local/include'` or `{'-I/usr/local/include', '-DDEBUG'}`).
+
+**NOTE**
+
+- Tilde (`~`) is **not** expanded. Use `$HOME` or absolute path instead (e.g. `-I$HOME/include` or `-I/home/user/include`).
+
+
+## configh:add_cppflags( flags )
+
+Appends cppflags to the existing list. Flags loaded from the `CPPFLAGS` environment variable are preserved.
+
+**Parameters**
+
+- `flags:string|string[]`: a cppflag string or an array of cppflag strings (e.g. `'-I/usr/local/include'` or `{'-I/usr/local/include', '-DDEBUG'}`).
 
 **NOTE**
 
 - The `CPPFLAGS` environment variable is automatically loaded when creating a `configh` object.
 - Tilde (`~`) is **not** expanded. Use `$HOME` or absolute path instead (e.g. `-I$HOME/include` or `-I/home/user/include`).
-
-
-## configh:remove_cppflag( flag )
-
-Removes a cppflag that was added by the `configh:add_cppflag` method.
-
-**Parameters**
-
-- `flag:string`: a cppflag string.
 
 
 ## configh:output_status( enabled )

--- a/lib/command.lua
+++ b/lib/command.lua
@@ -336,9 +336,7 @@ local function command(args, stdout, stderr)
 
     -- add cppflags
     if config.cppflags then
-        for _, flag in ipairs(config.cppflags) do
-            cfgh:add_cppflag(flag)
-        end
+        cfgh:add_cppflags(config.cppflags)
     end
 
     -- check headers

--- a/lib/configh.lua
+++ b/lib/configh.lua
@@ -168,16 +168,16 @@ function Configh:unset_feature(name)
     self.exec:unset_feature(name)
 end
 
---- add_cppflag add a cppflag
---- @param flag string
-function Configh:add_cppflag(flag)
-    self.exec:add_cppflag(flag)
+--- set_cppflags set cppflags, replacing any previously set flags
+--- @param flags string|string[]
+function Configh:set_cppflags(flags)
+    self.exec:set_cppflags(flags)
 end
 
---- remove_cppflag remove a cppflag
---- @param flag string
-function Configh:remove_cppflag(flag)
-    self.exec:remove_cppflag(flag)
+--- add_cppflags append cppflags to the existing list
+--- @param flags string|string[]
+function Configh:add_cppflags(flags)
+    self.exec:add_cppflags(flags)
 end
 
 -- Maps target name to the corresponding executor method name.

--- a/lib/executor.lua
+++ b/lib/executor.lua
@@ -36,7 +36,7 @@ local gcfn = require('gcfn')
 --- @class configh.executor
 --- @field cc string
 --- @field features table<string, integer>|table<integer, string>
---- @field cppflags table<string, integer>|table<integer, string>
+--- @field cppflags string[]
 --- @field buffile string
 --- @field buf file*
 local Executor = {}
@@ -71,10 +71,7 @@ function Executor:init(cc)
     local cppflags_str = getenv('CPPFLAGS')
     if cppflags_str then
         for flag in cppflags_str:gmatch('%S+') do
-            if not self.cppflags[flag] then
-                self.cppflags[#self.cppflags + 1] = flag
-                self.cppflags[flag] = #self.cppflags
-            end
+            self.cppflags[#self.cppflags + 1] = flag
         end
     end
 
@@ -270,29 +267,39 @@ function Executor:unset_feature(name)
     end
 end
 
---- add_cppflag add a cppflag
---- @param flag string
-function Executor:add_cppflag(flag)
-    assert(type(flag) == 'string', 'flag must be string')
-
-    local idx = self.cppflags[flag]
-    if idx then
-        self.cppflags[idx] = flag
-    else
-        self.cppflags[#self.cppflags + 1] = flag
-        self.cppflags[flag] = #self.cppflags
+--- add_flags validates and normalizes flags to a string array
+--- @param arr string[]
+--- @param flags string|string[]
+--- @return string[]
+local function add_flags(arr, flags)
+    assert(type(arr) == 'table', 'arr must be a table')
+    if type(flags) == 'string' then
+        arr[#arr + 1] = flags
+        return arr
+    elseif type(flags) ~= 'table' then
+        error('flags must be a string or string[]')
     end
+
+    -- validate and append flags to array
+    for i, v in ipairs(flags) do
+        if type(v) ~= 'string' then
+            error(format('flags#%d must be a string', i))
+        end
+        arr[#arr + 1] = v
+    end
+    return arr
 end
 
---- remove_cppflag remove a cppflag
---- @param flag string
-function Executor:remove_cppflag(flag)
-    assert(type(flag) == 'string', 'flag must be string')
+--- add_cppflags append cppflags to the existing list
+--- @param flags string|string[]
+function Executor:add_cppflags(flags)
+    add_flags(self.cppflags, flags)
+end
 
-    local idx = self.cppflags[flag]
-    if idx then
-        self.cppflags[idx] = ''
-    end
+--- set_cppflags set cppflags, replacing any previously set flags
+--- @param flags string|string[]
+function Executor:set_cppflags(flags)
+    self.cppflags = add_flags({}, flags)
 end
 
 --- check_header check the header is available

--- a/test/configh_test.lua
+++ b/test/configh_test.lua
@@ -159,26 +159,44 @@ function testcase.output_status()
     assert.match(stdout:read('*a'), 'check header: stdio.h ... found')
 end
 
-function testcase.add_and_remove_cppflag()
+function testcase.set_cppflags()
     local cfgh = configh('gcc')
 
-    -- test that add cppflag
-    cfgh:add_cppflag('-I/usr/local/include')
-    assert.is_uint(cfgh.exec.cppflags['-I/usr/local/include'])
-    assert.equal(cfgh.exec.cppflags[cfgh.exec.cppflags['-I/usr/local/include']],
-                 '-I/usr/local/include')
+    -- test that set cppflags with a string
+    cfgh:set_cppflags('-I/usr/local/include')
+    assert.equal(#cfgh.exec.cppflags, 1)
+    assert.equal(cfgh.exec.cppflags[1], '-I/usr/local/include')
 
-    -- test that add multiple cppflags
-    cfgh:add_cppflag('-I/opt/include')
-    cfgh:add_cppflag('-DDEBUG')
+    -- test that set cppflags with a string array
+    cfgh:set_cppflags({
+        '-I/usr/local/include',
+        '-I/opt/include',
+        '-DDEBUG',
+    })
     assert.equal(#cfgh.exec.cppflags, 3)
 
-    -- test that remove_cppflag blanks the slot; slot count unchanged
-    local idx = cfgh.exec.cppflags['-I/usr/local/include']
-    cfgh:remove_cppflag('-I/usr/local/include')
-    assert.is_uint(cfgh.exec.cppflags['-I/usr/local/include'])
-    assert.equal(cfgh.exec.cppflags[idx], '')
+    -- test that set_cppflags replaces the list
+    cfgh:set_cppflags({
+        '-I/new/path',
+    })
+    assert.equal(#cfgh.exec.cppflags, 1)
+    assert.equal(cfgh.exec.cppflags[1], '-I/new/path')
+end
+
+function testcase.add_cppflags()
+    local cfgh = configh('gcc')
+
+    -- test that add_cppflags appends to the existing list
+    cfgh:add_cppflags('-I/usr/local/include')
+    assert.equal(#cfgh.exec.cppflags, 1)
+    cfgh:add_cppflags({
+        '-I/opt/include',
+        '-DDEBUG',
+    })
     assert.equal(#cfgh.exec.cppflags, 3)
+    assert.equal(cfgh.exec.cppflags[1], '-I/usr/local/include')
+    assert.equal(cfgh.exec.cppflags[2], '-I/opt/include')
+    assert.equal(cfgh.exec.cppflags[3], '-DDEBUG')
 end
 
 function testcase.flush()

--- a/test/executor_test.lua
+++ b/test/executor_test.lua
@@ -260,46 +260,83 @@ function testcase.check_member()
     assert.match(err, 'member must be a string')
 end
 
-function testcase.add_and_remove_cppflag()
+function testcase.set_cppflags()
     local exec = executor('gcc')
 
-    -- test that add cppflag
-    exec:add_cppflag('-I/usr/local/include')
-    assert.is_uint(exec.cppflags['-I/usr/local/include'])
-    assert.equal(exec.cppflags[exec.cppflags['-I/usr/local/include']],
-                 '-I/usr/local/include')
+    -- test that set cppflags with a string
+    exec:set_cppflags('-I/usr/local/include')
+    assert.equal(#exec.cppflags, 1)
+    assert.equal(exec.cppflags[1], '-I/usr/local/include')
 
-    -- test that add multiple cppflags
-    exec:add_cppflag('-I/opt/include')
-    exec:add_cppflag('-DDEBUG')
+    -- test that set cppflags with a string array
+    exec:set_cppflags({
+        '-I/usr/local/include',
+        '-I/opt/include',
+        '-DDEBUG',
+    })
     assert.equal(#exec.cppflags, 3)
+    assert.equal(exec.cppflags[1], '-I/usr/local/include')
+    assert.equal(exec.cppflags[2], '-I/opt/include')
+    assert.equal(exec.cppflags[3], '-DDEBUG')
 
-    -- test that do not add duplicate cppflag (slot count unchanged)
-    exec:add_cppflag('-I/usr/local/include')
+    -- test that set_cppflags replaces the existing list
+    exec:set_cppflags({
+        '-I/new/path',
+    })
+    assert.equal(#exec.cppflags, 1)
+    assert.equal(exec.cppflags[1], '-I/new/path')
+
+    -- test that set_cppflags with empty array clears the list
+    exec:set_cppflags({})
+    assert.equal(#exec.cppflags, 0)
+
+    -- test that throws an error if flags is not string or table
+    local err = assert.throws(exec.set_cppflags, exec, 123)
+    assert.match(err, 'flags must be a string or string[]')
+
+    -- test that throws an error if an element of flags is not string
+    err = assert.throws(exec.set_cppflags, exec, {
+        '-I/usr/local/include',
+        123,
+    })
+    assert.match(err, 'flags#2 must be a string')
+end
+
+function testcase.add_cppflags()
+    local exec = executor('gcc')
+
+    -- test that add cppflags with a string
+    exec:add_cppflags('-I/usr/local/include')
+    assert.equal(#exec.cppflags, 1)
+    assert.equal(exec.cppflags[1], '-I/usr/local/include')
+
+    -- test that add cppflags with a string array appends to existing list
+    exec:add_cppflags({
+        '-I/opt/include',
+        '-DDEBUG',
+    })
     assert.equal(#exec.cppflags, 3)
+    assert.equal(exec.cppflags[1], '-I/usr/local/include')
+    assert.equal(exec.cppflags[2], '-I/opt/include')
+    assert.equal(exec.cppflags[3], '-DDEBUG')
 
-    -- test that remove_cppflag blanks the slot; flag key is retained
-    local idx = exec.cppflags['-I/usr/local/include']
-    exec:remove_cppflag('-I/usr/local/include')
-    assert.is_uint(exec.cppflags['-I/usr/local/include'])
-    assert.equal(exec.cppflags[idx], '')
-    assert.equal(#exec.cppflags, 3)
+    -- test that set_cppflags replaces all flags including those added via add_cppflags
+    exec:set_cppflags({
+        '-I/new/path',
+    })
+    assert.equal(#exec.cppflags, 1)
+    assert.equal(exec.cppflags[1], '-I/new/path')
 
-    -- test that add_cppflag reactivates the existing slot
-    exec:add_cppflag('-I/usr/local/include')
-    assert.equal(exec.cppflags['-I/usr/local/include'], idx)
-    assert.equal(exec.cppflags[idx], '-I/usr/local/include')
-    assert.equal(#exec.cppflags, 3)
+    -- test that throws an error if flags is not string or table
+    local err = assert.throws(exec.add_cppflags, exec, 123)
+    assert.match(err, 'flags must be a string or string[]')
 
-    -- test that remove non-existent cppflag does not throw error
-    exec:remove_cppflag('-I/nonexistent')
-    assert.equal(#exec.cppflags, 3)
-
-    -- test that throws an error if flag argument is not string
-    local err = assert.throws(exec.add_cppflag, exec, 123)
-    assert.match(err, 'flag must be string')
-    err = assert.throws(exec.remove_cppflag, exec, 123)
-    assert.match(err, 'flag must be string')
+    -- test that throws an error if an element of flags is not string
+    err = assert.throws(exec.add_cppflags, exec, {
+        '-I/usr/local/include',
+        123,
+    })
+    assert.match(err, 'flags#2 must be a string')
 end
 
 function testcase.check_decl()
@@ -334,9 +371,21 @@ function testcase.cppflags_env()
     -- test that load CPPFLAGS environment variable
     setenv('CPPFLAGS', '-I/usr/local/include -DDEBUG')
     local exec = executor('gcc')
-    assert.is_uint(exec.cppflags['-I/usr/local/include'])
-    assert.is_uint(exec.cppflags['-DDEBUG'])
     assert.equal(#exec.cppflags, 2)
+    assert.equal(exec.cppflags[1], '-I/usr/local/include')
+    assert.equal(exec.cppflags[2], '-DDEBUG')
+
+    -- test that add_cppflags appends to env-loaded flags
+    exec:add_cppflags('-I/opt/include')
+    assert.equal(#exec.cppflags, 3)
+    assert.equal(exec.cppflags[3], '-I/opt/include')
+
+    -- test that set_cppflags replaces env-loaded flags
+    exec:set_cppflags({
+        '-I/new/path',
+    })
+    assert.equal(#exec.cppflags, 1)
+    assert.equal(exec.cppflags[1], '-I/new/path')
     setenv('CPPFLAGS', nil)
 
     -- test that CPPFLAGS environment variable is empty


### PR DESCRIPTION
This pull request refactors how preprocessor flags (`cppflags`) are managed in the codebase. The previous methods for adding and removing individual flags have been replaced with clearer, more flexible methods for setting or appending multiple flags at once. The changes also update documentation and tests to match the new API and simplify internal data structures.

**API and Internal Refactoring:**

* Replaced `add_cppflag` and `remove_cppflag` methods with `set_cppflags` (replaces all flags) and `add_cppflags` (appends to the list) in both `Configh` and `Executor` classes. The new methods accept either a single string or an array of strings, improving usability and consistency. [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L171-R180) [[2]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L273-R302)
* Changed the internal representation of `cppflags` from a table with string keys to a simple array of strings, simplifying code and removing duplicate flag checks. [[1]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L39-R39) [[2]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L74-L77)

**Documentation Updates:**

* Updated the `README.md` to document the new `set_cppflags` and `add_cppflags` methods, including their parameters and behavior, and removed references to the old methods. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L324-R348) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L239-R239)

**Test Suite Updates:**

* Refactored and expanded tests to cover the new API, including edge cases for invalid input and correct flag ordering. Tests now verify both the `set_cppflags` and `add_cppflags` behaviors. [[1]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748L162-R199) [[2]](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0L263-R339) [[3]](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0L337-R388)

These changes result in a simpler, more robust, and easier-to-use interface for managing preprocessor flags.