### PR TITLE
Add check_sizeof to determine C type sizes at build time

### DIFF
--- a/lib/configh.lua
+++ b/lib/configh.lua
@@ -41,6 +41,7 @@ local DECL_KIND = {
     types = 'type',
     decls = 'decl',
     members = 'member',
+    sizeof = 'sizeof',
 }
 
 --- @class configh
@@ -60,6 +61,7 @@ function Configh:init(cc)
         types = {},
         decls = {},
         members = {},
+        sizeof = {},
     }
     self.exec = executor(cc)
     self.output = false
@@ -114,14 +116,24 @@ function Configh:flush(pathname)
 
     -- iterate inspected in insertion order; HAVE_ conversion happens here
     for _, entry in ipairs(self.inspected) do
-        local fqname = (entry.target == 'headers' and '<%s>' or "`%s'"):format(
-                           entry.fqname)
         local macro_name = entry.fqname:upper():gsub('[^%w]', '_')
-        lines[#lines + 1] = format('/* Define to 1 if you have the %s %s. */',
-                                   fqname, DECL_KIND[entry.target])
-        lines[#lines + 1] = entry.is_exists and
-                                format('#define HAVE_%s 1', macro_name) or
-                                format('/* #undef HAVE_%s */', macro_name)
+        if entry.target == 'sizeof' then
+            lines[#lines + 1] = format('/* Size of `%s`. */', entry.fqname)
+            lines[#lines + 1] = entry.is_exists and
+                                    format('#define SIZEOF_%s %d', macro_name,
+                                           entry.size) or
+                                    format('/* #undef SIZEOF_%s */', macro_name)
+        else
+            local fqname =
+                (entry.target == 'headers' and '<%s>' or "`%s'"):format(
+                    entry.fqname)
+            lines[#lines + 1] = format(
+                                    '/* Define to 1 if you have the %s %s. */',
+                                    fqname, DECL_KIND[entry.target])
+            lines[#lines + 1] = entry.is_exists and
+                                    format('#define HAVE_%s 1', macro_name) or
+                                    format('/* #undef HAVE_%s */', macro_name)
+        end
         lines[#lines + 1] = ''
     end
     self.inspected = {
@@ -130,6 +142,7 @@ function Configh:flush(pathname)
         types = {},
         decls = {},
         members = {},
+        sizeof = {},
     }
 
     -- output messages
@@ -247,6 +260,7 @@ local EXEC_METHOD = {
     types = 'check_type',
     decls = 'check_decl',
     members = 'check_member',
+    sizeof = 'check_sizeof',
 }
 
 --- check executes a probe via the EXEC_METHOD dispatch table and records
@@ -257,18 +271,18 @@ local EXEC_METHOD = {
 ---   headers  string|table|nil  include headers passed to the executor
 ---                               (for 'headers' target: the header being checked)
 ---   declname string             primary declaration name (header, func/type/decl name,
----                               or struct/union type name for 'members')
+---                               or struct/union type name for 'members'/'sizeof')
 ---   member   string?            member field name ('members' target only)
 ---   fqname   string?            fully qualified name used for display, hash key, and
 ---                               HAVE_ macro (defaults to declname; 'declname.member' for members)
 --- @param self configh
---- @param target string  'headers'|'funcs'|'types'|'decls'|'members'
+--- @param target string  'headers'|'funcs'|'types'|'decls'|'members'|'sizeof'
 --- @param params table
 --- @return boolean ok
 --- @return string? err
 local function check(self, target, params)
     assert(EXEC_METHOD[target] ~= nil,
-           "target must be 'headers', 'funcs', 'types', 'decls' or 'members'")
+           "target must be 'headers', 'funcs', 'types', 'decls', 'members' or 'sizeof'")
     assert(type(params) == 'table', 'params must be table')
     assert(type(params.declname) == 'string', 'params.declname must be string')
     assert(params.headers == nil or type(params.headers) == 'string' or
@@ -282,10 +296,15 @@ local function check(self, target, params)
     local fqname = params.fqname or params.declname
 
     printf(self, 'check %s: %s ... ', DECL_KIND[target], fqname)
-    local ok, err = self.exec[EXEC_METHOD[target]](self.exec, params.headers,
-                                                   params.declname,
-                                                   params.member)
-    printf(self, ok and 'found\n' or 'not found\n')
+    local ok, err, extra = self.exec[EXEC_METHOD[target]](self.exec,
+                                                          params.headers,
+                                                          params.declname,
+                                                          params.member)
+    if target == 'sizeof' then
+        printf(self, ok and format('%d\n', extra) or 'unknown\n')
+    else
+        printf(self, ok and 'found\n' or 'not found\n')
+    end
     if not ok and err then
         printf(self, '  >  ' .. gsub(err, '\n', '\n  >  '), '\n')
     end
@@ -294,6 +313,7 @@ local function check(self, target, params)
     if entry then
         -- dedup: update is_exists but keep the existing integer-indexed slot
         entry.is_exists = ok
+        entry.size = target == 'sizeof' and extra or entry.size
         return ok, err
     end
 
@@ -305,6 +325,7 @@ local function check(self, target, params)
         is_exists = ok,
         order = n,
         member = params.member,
+        size = target == 'sizeof' and extra or nil,
     }
     self.inspected[target][fqname] = entry
     self.inspected[n] = entry
@@ -376,6 +397,21 @@ function Configh:check_member(headers, ctype, member)
         declname = ctype,
         member = member,
         fqname = ctype .. '.' .. member,
+    })
+end
+
+--- check_sizeof determines the size of a C type at compile time and records
+--- the result in inspected.sizeof. The size can be read back via
+--- inspected.sizeof[ctype].size after a successful call.
+--- @param headers string|string[]|nil
+--- @param ctype string
+--- @return boolean ok
+--- @return string? err
+function Configh:check_sizeof(headers, ctype)
+    assert(type(ctype) == 'string', 'ctype must be a string')
+    return check(self, 'sizeof', {
+        headers = headers,
+        declname = ctype,
     })
 end
 

--- a/lib/executor.lua
+++ b/lib/executor.lua
@@ -159,8 +159,14 @@ function Executor:preprocess(opts)
     return false, read_error(self)
 end
 
---- compile runs the compiler in syntax-only mode to check declarations
---- @param opts table  { headers: string|string[]|nil, code: string|nil }
+--- compile runs the compiler to check declarations.
+--- Without opts.outfile it uses -fsyntax-only (no output file).
+--- With opts.outfile it compiles to an object file with -c.
+--- opts fields:
+---   headers  string|string[]|nil  include headers
+---   code     string?              code placed inside main()
+---   outfile  string?              path for the produced .o; enables -c mode
+--- @param opts table
 --- @return boolean ok
 --- @return string? err
 function Executor:compile(opts)
@@ -171,7 +177,7 @@ function Executor:compile(opts)
         concat(self.cppflags, ' '),
         flags_flatten(self.incdirs, '-I'),
         concat(self.cflags, ' '),
-        '-fsyntax-only',
+        not opts.outfile and '-fsyntax-only' or '-c -o ' .. opts.outfile,
         srcfile,
         '2>',
         self.buffile,
@@ -181,11 +187,17 @@ function Executor:compile(opts)
     if ok then
         return true
     end
+    if opts.outfile then
+        remove(opts.outfile)
+    end
     return false, read_error(self)
 end
 
 --- link compiles and links to verify a symbol exists in the current libraries
---- @param opts table  { headers: string|string[]|nil, code: string|nil }
+--- opts fields:
+---   headers  string|string[]|nil  include headers
+---   code     string?              code placed inside main()
+--- @param opts table
 --- @return boolean ok
 --- @return string? err
 function Executor:link(opts)
@@ -240,10 +252,7 @@ function Executor:makecsrc(headers, code)
     headers = concat(includes, '\n')
 
     -- check code
-    if code ~= nil then
-        assert(type(code) == 'string', 'code must be a string or nil')
-        code = code .. ';'
-    end
+    assert(code == nil or type(code) == 'string', 'code must be a string or nil')
 
     -- feature macros
     local features = concat(self.features, '\n')
@@ -430,7 +439,7 @@ function Executor:check_func(headers, func)
     assert(type(func) == 'string', 'func must be a string')
     return self:link({
         headers = headers,
-        code = format('void (*function_pointer)(void) = (void (*)(void))%s',
+        code = format('void (*function_pointer)(void) = (void (*)(void))%s;',
                       func),
     })
 end
@@ -444,7 +453,7 @@ function Executor:check_type(headers, ctype)
     assert(type(ctype) == 'string', 'type must be a string')
     return self:compile({
         headers = headers,
-        code = format('%s x', ctype),
+        code = format('%s x;', ctype),
     })
 end
 
@@ -472,8 +481,90 @@ function Executor:check_member(headers, ctype, member)
     assert(type(member) == 'string', 'member must be a string')
     return self:compile({
         headers = headers,
-        code = format('%s x; (void)x.%s', ctype, member),
+        code = format('%s x; (void)x.%s;', ctype, member),
     })
+end
+
+--- check_sizeof determines the size of a C type by embedding sizeof() as
+--- explicit big-endian bytes in a global array within the compiled object
+--- file, then scanning the binary to extract the value.  The per-call
+--- unique objfile path is used as the signature, so false matches against
+--- any content from user-specified headers cannot occur.
+--- @param headers string|string[]|nil
+--- @param ctype string
+--- @return boolean ok
+--- @return string? err
+--- @return integer? size  the sizeof(ctype), or nil if undetermined
+function Executor:check_sizeof(headers, ctype)
+    assert(type(ctype) == 'string', 'ctype must be a string')
+
+    local objfile = tmpname() .. '.o'
+    -- Encode the unique objfile path as decimal byte values so it can be
+    -- used as the signature inside the C initializer without quoting issues.
+    -- The reversed path is used as the end marker so that size=0 can be
+    -- distinguished from "signature not found".
+    local sig = objfile
+    local sig_end = sig:reverse()
+    local sig_c, sig_end_c = {}, {}
+    for i = 1, #sig do
+        sig_c[i] = sig:byte(i)
+        sig_end_c[i] = sig_end:byte(i)
+    end
+
+    -- Cast to unsigned long long before shifting to avoid UB on 32-bit
+    -- targets where sizeof(T) may be a 32-bit size_t.
+    local varname = 'configh_sizeof_' .. ctype:gsub('[^%w]', '_')
+    local code = ([[
+static unsigned char $VARNAME[] = {
+    $SIG,
+    (unsigned char)(((unsigned long long)sizeof($CTYPE) >> 56) & 0xFF),
+    (unsigned char)(((unsigned long long)sizeof($CTYPE) >> 48) & 0xFF),
+    (unsigned char)(((unsigned long long)sizeof($CTYPE) >> 40) & 0xFF),
+    (unsigned char)(((unsigned long long)sizeof($CTYPE) >> 32) & 0xFF),
+    (unsigned char)(((unsigned long long)sizeof($CTYPE) >> 24) & 0xFF),
+    (unsigned char)(((unsigned long long)sizeof($CTYPE) >> 16) & 0xFF),
+    (unsigned char)(((unsigned long long)sizeof($CTYPE) >>  8) & 0xFF),
+    (unsigned char)(((unsigned long long)sizeof($CTYPE) >>  0) & 0xFF),
+    $SIG_END
+};
+return (int)((char*)&$VARNAME - (char*)0);]]):gsub('%$([A-Z_]+)', {
+        VARNAME = varname,
+        SIG = concat(sig_c, ','),
+        SIG_END = concat(sig_end_c, ','),
+        CTYPE = ctype,
+    })
+
+    local ok, err = self:compile({
+        headers = headers,
+        code = code,
+        outfile = objfile,
+    })
+    if not ok then
+        return false, err
+    end
+
+    -- read object binary and locate the size bytes between the two signatures
+    local bf = assert(open(objfile, 'rb'))
+    local data = assert(bf:read('*a'))
+    bf:close()
+    remove(objfile)
+
+    -- search for the signature and verify the end marker follows the size bytes
+    local pos = data:find(sig, 1, true)
+    if not pos then
+        return false, format('unable to determine sizeof(%s)', ctype)
+    end
+    local size_start = pos + #sig
+    if data:sub(size_start + 8, size_start + 7 + #sig_end) ~= sig_end then
+        return false, format('unable to determine sizeof(%s)', ctype)
+    end
+
+    -- the 8 bytes between the two signatures are the size in big-endian order
+    local size = 0
+    for i = 0, 7 do
+        size = size * 256 + data:byte(size_start + i)
+    end
+    return true, nil, size
 end
 
 Executor = require('metamodule').new(Executor)

--- a/test/configh_test.lua
+++ b/test/configh_test.lua
@@ -146,6 +146,45 @@ function testcase.check_decl()
     assert.equal(cfgh.inspected.decls['UNKNOWN_CONSTANT'].is_exists, false)
 end
 
+function testcase.check_sizeof()
+    local cfgh = configh('gcc')
+
+    -- test that returns true for a known type
+    local ok, err = cfgh:check_sizeof(nil, 'char')
+    assert.is_true(ok)
+    assert.is_nil(err)
+    -- confirm that the entry is recorded in inspected.sizeof keyed by type name
+    local entry = cfgh.inspected.sizeof['char']
+    assert.not_nil(entry)
+    assert.equal(entry.is_exists, true)
+    assert.equal(entry.size, 1)
+
+    -- test that records the correct size for size_t with header
+    ok, err = cfgh:check_sizeof('stddef.h', 'size_t')
+    assert.is_true(ok)
+    assert.is_nil(err)
+    local size_t_entry = cfgh.inspected.sizeof['size_t']
+    assert.not_nil(size_t_entry)
+    assert.is_true(size_t_entry.size > 0)
+
+    -- test that dedup: calling twice returns the same entry
+    local entry_first = cfgh.inspected.sizeof['char']
+    cfgh:check_sizeof(nil, 'char')
+    assert.equal(cfgh.inspected.sizeof['char'], entry_first)
+
+    -- test that returns false for an unknown type
+    ok, err = cfgh:check_sizeof(nil, 'no_such_type_t')
+    assert.is_false(ok)
+    assert.is_string(err)
+    local unknown_entry = cfgh.inspected.sizeof['no_such_type_t']
+    assert.not_nil(unknown_entry)
+    assert.equal(unknown_entry.is_exists, false)
+
+    -- test that throws an error if ctype is not string
+    err = assert.throws(cfgh.check_sizeof, cfgh, nil, 123)
+    assert.match(err, 'ctype must be a string')
+end
+
 function testcase.output_status()
     local cfgh = configh('gcc')
     local stdout = assert(io.tmpfile())
@@ -377,6 +416,8 @@ function testcase.flush()
     cfgh:set_feature('_GNU_SOURCE')
     assert(cfgh:check_header('stdio.h'))
     assert(cfgh:check_func('stdio.h', 'printf'))
+    assert(cfgh:check_sizeof(nil, 'char'))
+    cfgh:check_sizeof(nil, 'no_such_type_t')
 
     -- test that check whether the function is available
     local ok, err = cfgh:flush('./test_config.h')
@@ -391,8 +432,9 @@ function testcase.flush()
         '\n#define _GNU_SOURCE\n',
         '\n#define HAVE_STDIO_H 1\n',
         '\n#define HAVE_PRINTF 1\n',
+        '\n#define SIZEOF_CHAR 1\n',
+        '\n/* #undef SIZEOF_NO_SUCH_TYPE_T */\n',
     }) do
-        assert.match(content, pattern)
         assert.match(content, pattern)
     end
 

--- a/test/executor_test.lua
+++ b/test/executor_test.lua
@@ -44,7 +44,7 @@ function testcase.makecsrc()
     local exec = executor('gcc')
 
     -- test that create a new c source file
-    local pathname = exec:makecsrc('stdio.h', 'test_t x')
+    local pathname = exec:makecsrc('stdio.h', 'test_t x;')
     local f = assert(io.open(pathname, 'r'))
     os.remove(pathname)
     local src = f:read('*a')
@@ -142,14 +142,14 @@ function testcase.compile()
     -- test that compile succeeds for an existing type (with header)
     local ok, err = exec:compile({
         headers = 'sys/socket.h',
-        code = 'struct sockaddr_storage x',
+        code = 'struct sockaddr_storage x;',
     })
     assert.is_true(ok)
     assert.is_nil(err)
 
     -- test that compile fails for an unknown type
     ok, err = exec:compile({
-        code = 'unknown_type_xyz_for_test x',
+        code = 'unknown_type_xyz_for_test x;',
     })
     assert.is_false(ok)
     assert.is_string(err)
@@ -161,14 +161,14 @@ function testcase.link()
     -- test that link succeeds for an existing function (with header)
     local ok, err = exec:link({
         headers = 'stdio.h',
-        code = 'void (*fp)(void) = (void (*)(void))printf',
+        code = 'void (*fp)(void) = (void (*)(void))printf;',
     })
     assert.is_true(ok)
     assert.is_nil(err)
 
     -- test that link fails for a nonexistent function
     ok, err = exec:link({
-        code = 'void (*fp)(void) = (void (*)(void))nonexistent_func_xyz_for_test',
+        code = 'void (*fp)(void) = (void (*)(void))nonexistent_func_xyz_for_test;',
     })
     assert.is_false(ok)
     assert.is_string(err)
@@ -258,6 +258,40 @@ function testcase.check_member()
     err = assert.throws(exec.check_member, exec, 'sys/socket.h',
                         'struct sockaddr', 123)
     assert.match(err, 'member must be a string')
+end
+
+function testcase.check_sizeof()
+    local exec = executor('gcc')
+
+    -- test that returns the size of a primitive type
+    local ok, err, size = exec:check_sizeof(nil, 'char')
+    assert.is_true(ok)
+    assert.is_nil(err)
+    assert.equal(size, 1)
+
+    -- test that returns the correct size for int (typically 4)
+    ok, err, size = exec:check_sizeof(nil, 'int')
+    assert.is_true(ok)
+    assert.is_nil(err)
+    assert.is_number(size)
+    assert.is_true(size > 0)
+
+    -- test that returns size using a header type
+    ok, err, size = exec:check_sizeof('stddef.h', 'size_t')
+    assert.is_true(ok)
+    assert.is_nil(err)
+    assert.is_number(size)
+    assert.is_true(size > 0)
+
+    -- test that returns nil for an unknown type
+    ok, err, size = exec:check_sizeof(nil, 'no_such_type_t')
+    assert.is_false(ok)
+    assert.is_string(err)
+    assert.is_nil(size)
+
+    -- test that throws an error if ctype argument is not string
+    err = assert.throws(exec.check_sizeof, exec, nil, 123)
+    assert.match(err, 'ctype must be a string')
 end
 
 function testcase.set_cppflags()


### PR DESCRIPTION
This pull request adds support for checking the size of C types at compile time in the configuration system. It introduces a new `check_sizeof` method to both the executor and configuration logic, updates the output and internal storage to handle type sizes, and adds comprehensive tests for this new functionality. Several minor improvements and fixes were also made to ensure code consistency and correctness.

**New feature: Sizeof checks**
* Added `check_sizeof` method to both `Executor` and `Configh` classes, enabling the system to determine and record the size of C types at compile time. The size is extracted from a compiled object file using a unique signature to avoid false positives. (`lib/executor.lua`, `lib/configh.lua`) [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R403-R417) [[2]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L475-R567)
* Updated internal data structures and output logic to store and emit `SIZEOF_*` macros for detected types, and to handle cases where the type is not found. (`lib/configh.lua`) [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R44) [[2]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R64) [[3]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L117-R136) [[4]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R145)

**API and code consistency improvements**
* Standardized code snippets in compile/link/type/member checks to always include semicolons, ensuring valid C code generation. (`lib/executor.lua`, `test/executor_test.lua`) [[1]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L447-R456) [[2]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L433-R442) [[3]](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0L47-R47) [[4]](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0L145-R152) [[5]](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0L164-R171) [[6]](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0R263-R296)
* Improved documentation for compile and link methods, and clarified parameter expectations. (`lib/executor.lua`) [[1]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L162-R169) [[2]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L243-R255)

**Testing**
* Added comprehensive tests for the new `check_sizeof` functionality, including success, failure, deduplication, and error handling cases. (`test/configh_test.lua`, `test/executor_test.lua`) [[1]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748R149-R187) [[2]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748R419-R420) [[3]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748R435-L396) [[4]](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0R263-R296)

**Internal logic and error handling**
* Enhanced deduplication logic for `sizeof` entries and improved error handling for invalid arguments. (`lib/configh.lua`) [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R316) [[2]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R328) [[3]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L285-R307) [[4]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L260-R285) [[5]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R263)

Overall, these changes extend the configuration system's capabilities to robustly detect and record C type sizes, improving its utility for build-time feature detection and configuration.