### PR TITLE
Refactor executor probe methods to use a uniform params table

### DIFF
--- a/lib/configh.lua
+++ b/lib/configh.lua
@@ -116,20 +116,20 @@ function Configh:flush(pathname)
 
     -- iterate inspected in insertion order; HAVE_ conversion happens here
     for _, entry in ipairs(self.inspected) do
-        local macro_name = entry.fqname:upper():gsub('[^%w]', '_')
+        local macro_name = entry.name:upper():gsub('[^%w]', '_')
         if entry.target == 'sizeof' then
-            lines[#lines + 1] = format('/* Size of `%s`. */', entry.fqname)
+            lines[#lines + 1] = format('/* Size of `%s`. */', entry.name)
             lines[#lines + 1] = entry.is_exists and
                                     format('#define SIZEOF_%s %d', macro_name,
                                            entry.size) or
                                     format('/* #undef SIZEOF_%s */', macro_name)
         else
-            local fqname =
+            local display =
                 (entry.target == 'headers' and '<%s>' or "`%s'"):format(
-                    entry.fqname)
+                    entry.name)
             lines[#lines + 1] = format(
                                     '/* Define to 1 if you have the %s %s. */',
-                                    fqname, DECL_KIND[entry.target])
+                                    display, DECL_KIND[entry.target])
             lines[#lines + 1] = entry.is_exists and
                                     format('#define HAVE_%s 1', macro_name) or
                                     format('/* #undef HAVE_%s */', macro_name)
@@ -264,17 +264,16 @@ local EXEC_METHOD = {
 }
 
 --- check executes a probe via the EXEC_METHOD dispatch table and records
---- the result in inspected. If the fqname is already registered under
+--- the result in inspected. If the name is already registered under
 --- target, the existing entry's is_exists is updated without adding a new
 --- integer-indexed slot, preventing duplicate lines in config.h output.
---- params fields:
----   headers  string|table|nil  include headers passed to the executor
----                               (for 'headers' target: the header being checked)
----   declname string             primary declaration name (header, func/type/decl name,
----                               or struct/union type name for 'members'/'sizeof')
----   member   string?            member field name ('members' target only)
----   fqname   string?            fully qualified name used for display, hash key, and
----                               HAVE_ macro (defaults to declname; 'declname.member' for members)
+--- check() validates only the fields it directly references:
+---   name     string   C identifier or type name; used as the hash key,
+---                     display label, and HAVE_/SIZEOF_ macro base.
+---                     For 'members', the stored key becomes "name.member".
+---   member   string   member field name ('members' target only, required)
+--- All other fields (headers, ...) are passed through to the executor
+--- without validation here; each executor method validates its own fields.
 --- @param self configh
 --- @param target string  'headers'|'funcs'|'types'|'decls'|'members'|'sizeof'
 --- @param params table
@@ -284,134 +283,125 @@ local function check(self, target, params)
     assert(EXEC_METHOD[target] ~= nil,
            "target must be 'headers', 'funcs', 'types', 'decls', 'members' or 'sizeof'")
     assert(type(params) == 'table', 'params must be table')
-    assert(type(params.declname) == 'string', 'params.declname must be string')
-    assert(params.headers == nil or type(params.headers) == 'string' or
-               type(params.headers) == 'table',
-           'params.headers must be string, table or nil')
-    assert(params.member == nil or type(params.member) == 'string',
-           'params.member must be string or nil')
-    assert(params.fqname == nil or type(params.fqname) == 'string',
-           'params.fqname must be string or nil')
+    assert(type(params.name) == 'string', 'params.name must be string')
 
-    local fqname = params.fqname or params.declname
+    local name = params.name
+    -- for members the inspected key is "type.member"; for all other targets
+    -- it equals params.name directly
+    if target == 'members' then
+        assert(type(params.member) == 'string',
+               'params.member must be string for members target')
+        name = name .. '.' .. params.member
+    end
+    printf(self, 'check %s: %s ... ', DECL_KIND[target], name)
 
-    printf(self, 'check %s: %s ... ', DECL_KIND[target], fqname)
-    local ok, err, extra = self.exec[EXEC_METHOD[target]](self.exec,
-                                                          params.headers,
-                                                          params.declname,
-                                                          params.member)
-    if target == 'sizeof' then
-        printf(self, ok and format('%d\n', extra) or 'unknown\n')
+    local ok, err, extra = self.exec[EXEC_METHOD[target]](self.exec, params)
+    if not ok then
+        printf(self, 'not found\n')
+        if err then
+            printf(self, '%s\n', '  >  ' .. gsub(err, '\n', '\n  >  '))
+        end
+    elseif target == 'sizeof' then
+        printf(self, 'found (%s)\n', tostring(extra))
     else
-        printf(self, ok and 'found\n' or 'not found\n')
-    end
-    if not ok and err then
-        printf(self, '  >  ' .. gsub(err, '\n', '\n  >  '), '\n')
+        printf(self, 'found\n')
     end
 
-    local entry = self.inspected[target][fqname]
-    if entry then
-        -- dedup: update is_exists but keep the existing integer-indexed slot
-        entry.is_exists = ok
-        entry.size = target == 'sizeof' and extra or entry.size
-        return ok, err
+    local entry = self.inspected[target][name]
+    if not entry then
+        entry = {
+            target = target,
+            name = name,
+            is_exists = ok,
+            member = target == 'members' and params.member or nil,
+        }
+        self.inspected[target][name] = entry
+        self.inspected[#self.inspected + 1] = entry
     end
-
-    local n = #self.inspected + 1
-    entry = {
-        target = target,
-        fqname = fqname,
-        declname = params.declname,
-        is_exists = ok,
-        order = n,
-        member = params.member,
-        size = target == 'sizeof' and extra or nil,
-    }
-    self.inspected[target][fqname] = entry
-    self.inspected[n] = entry
+    entry.is_exists = ok
+    entry.size = target == 'sizeof' and extra or nil
     return ok, err
 end
 
 --- check_header check whether the header file exists
---- @param header string
+--- @param header string  header file path (e.g. "stdio.h", "sys/socket.h")
 --- @return boolean ok true if the header file exists
 --- @return string? err error message from the compiler
 function Configh:check_header(header)
     assert(type(header) == 'string', 'header must be string')
     return check(self, 'headers', {
+        name = header,
         headers = header,
-        declname = header,
     })
 end
 
 --- check_func check whether the function exists
---- @param headers string|string[]|nil
---- @param func string
+--- @param headers string|string[]|nil  header files that declare the function
+--- @param name string  function name (e.g. "printf")
 --- @return boolean ok true if the function exists
 --- @return string? err error message from the compiler
-function Configh:check_func(headers, func)
-    assert(type(func) == 'string', 'func must be string')
+function Configh:check_func(headers, name)
+    assert(type(name) == 'string', 'name must be string')
     return check(self, 'funcs', {
+        name = name,
         headers = headers,
-        declname = func,
     })
 end
 
 --- check_type check whether the type exists
---- @param headers string|string[]|nil
---- @param ctype string
+--- @param headers string|string[]|nil  header files that declare the type
+--- @param name string  C type name (e.g. "struct sockaddr_storage")
 --- @return boolean ok true if the type exists
 --- @return string? err error message from the compiler
-function Configh:check_type(headers, ctype)
-    assert(type(ctype) == 'string', 'ctype must be string')
+function Configh:check_type(headers, name)
+    assert(type(name) == 'string', 'name must be string')
     return check(self, 'types', {
+        name = name,
         headers = headers,
-        declname = ctype,
     })
 end
 
 --- check_decl check whether named symbol is defined as a macro or can be used as an r-value
---- @param headers string|string[]|nil
---- @param name string
+--- @param headers string|string[]|nil  header files that declare the symbol
+--- @param name string  symbol name (e.g. "PATH_MAX", "O_RDONLY")
 --- @return boolean ok true if the declaration exists
 --- @return string? err error message from the compiler
 function Configh:check_decl(headers, name)
     assert(type(name) == 'string', 'name must be string')
     return check(self, 'decls', {
+        name = name,
         headers = headers,
-        declname = name,
     })
 end
 
 --- check_member check whether the member field exists
---- @param headers string|string[]|nil
---- @param ctype string
---- @param member string
+--- @param headers string|string[]|nil  header files that declare the struct
+--- @param name string  C struct type name (e.g. "struct sockaddr")
+--- @param member string  member field name (e.g. "sa_family")
 --- @return boolean ok true if the member exists
 --- @return string? err error message from the compiler
-function Configh:check_member(headers, ctype, member)
-    assert(type(ctype) == 'string', 'ctype must be string')
+function Configh:check_member(headers, name, member)
+    assert(type(name) == 'string', 'name must be string')
     assert(type(member) == 'string', 'member must be string')
     return check(self, 'members', {
+        name = name,
         headers = headers,
-        declname = ctype,
         member = member,
-        fqname = ctype .. '.' .. member,
     })
 end
 
 --- check_sizeof determines the size of a C type at compile time and records
 --- the result in inspected.sizeof. The size can be read back via
---- inspected.sizeof[ctype].size after a successful call.
---- @param headers string|string[]|nil
---- @param ctype string
+--- inspected.sizeof[name].size after a successful call.
+--- @param headers string|string[]|nil  header files that declare the type
+--- @param name string  C type name (e.g. "size_t", "struct sockaddr")
 --- @return boolean ok
 --- @return string? err
-function Configh:check_sizeof(headers, ctype)
-    assert(type(ctype) == 'string', 'ctype must be a string')
+function Configh:check_sizeof(headers, name)
+    assert(type(name) == 'string', 'name must be a string')
     return check(self, 'sizeof', {
+        name = name,
         headers = headers,
-        declname = ctype,
     })
 end
 

--- a/lib/executor.lua
+++ b/lib/executor.lua
@@ -421,67 +421,71 @@ function Executor:set_ldflags(flags)
 end
 
 --- check_header check the header is available
---- @param headers string|string[]
+--- @param params table  { headers: string }
 --- @return boolean ok
 --- @return string? err
-function Executor:check_header(headers)
+function Executor:check_header(params)
+    assert(type(params) == 'table', 'params must be a table')
+    assert(type(params.headers) == 'string', 'params.headers must be a string')
     return self:preprocess({
-        headers = headers,
+        headers = params.headers,
     })
 end
 
 --- check_func check the function is available
---- @param headers string|string[]|nil
---- @param func string
+--- @param params table  { headers: string|string[]|nil, name: string }
 --- @return boolean ok
 --- @return string? err
-function Executor:check_func(headers, func)
-    assert(type(func) == 'string', 'func must be a string')
+function Executor:check_func(params)
+    assert(type(params) == 'table', 'params must be a table')
+    assert(type(params.name) == 'string', 'params.name must be a string')
     return self:link({
-        headers = headers,
+        headers = params.headers,
         code = format('void (*function_pointer)(void) = (void (*)(void))%s;',
-                      func),
+                      params.name),
     })
 end
 
 --- check_type check the type is available
---- @param headers string|string[]|nil
---- @param ctype string
+--- @param params table  { headers: string|string[]|nil, name: string }
+---                      name is the C type name (e.g. "struct sockaddr_storage")
 --- @return boolean ok
 --- @return string? err
-function Executor:check_type(headers, ctype)
-    assert(type(ctype) == 'string', 'type must be a string')
+function Executor:check_type(params)
+    assert(type(params) == 'table', 'params must be a table')
+    assert(type(params.name) == 'string', 'params.name must be a string')
     return self:compile({
-        headers = headers,
-        code = format('%s x;', ctype),
+        headers = params.headers,
+        code = format('%s x;', params.name),
     })
 end
 
 --- check_decl check whether named symbol is defined as a macro or can be used as an r-value
---- @param headers string|string[]|nil
---- @param name string
+--- @param params table  { headers: string|string[]|nil, name: string }
 --- @return boolean ok
 --- @return string? err
-function Executor:check_decl(headers, name)
-    assert(type(name) == 'string', 'name must be a string')
+function Executor:check_decl(params)
+    assert(type(params) == 'table', 'params must be a table')
+    assert(type(params.name) == 'string', 'params.name must be a string')
     return self:compile({
-        headers = headers,
-        code = format('#ifndef %s\n    (void)%s;\n#endif\n\n', name, name),
+        headers = params.headers,
+        code = format('#ifndef %s\n    (void)%s;\n#endif\n\n', params.name,
+                      params.name),
     })
 end
 
 --- check_member check the member field is available
---- @param headers string|string[]|nil
---- @param ctype string
---- @param member string
+--- @param params table  { headers: string|string[]|nil, name: string, member: string }
+---                      name is the C struct type name (e.g. "struct sockaddr")
 --- @return boolean ok
 --- @return string? err
-function Executor:check_member(headers, ctype, member)
-    assert(type(ctype) == 'string', 'type must be a string')
-    assert(type(member) == 'string', 'member must be a string')
+function Executor:check_member(params)
+    assert(type(params) == 'table', 'params must be a table')
+    assert(type(params.name) == 'string', 'params.name must be a string')
+    assert(type(params.member) == 'string', 'params.member must be a string')
     return self:compile({
-        headers = headers,
-        code = format('%s x; (void)x.%s;', ctype, member),
+        headers = params.headers,
+        code = format('%s x; (void)x.%s;', params.name, params.member),
     })
 end
 
@@ -490,13 +494,14 @@ end
 --- file, then scanning the binary to extract the value.  The per-call
 --- unique objfile path is used as the signature, so false matches against
 --- any content from user-specified headers cannot occur.
---- @param headers string|string[]|nil
---- @param ctype string
+--- @param params table  { headers: string|string[]|nil, name: string }  name is the C type name (e.g. "size_t")
 --- @return boolean ok
 --- @return string? err
---- @return integer? size  the sizeof(ctype), or nil if undetermined
-function Executor:check_sizeof(headers, ctype)
-    assert(type(ctype) == 'string', 'ctype must be a string')
+--- @return integer? size  the sizeof(params.name), or nil if undetermined
+function Executor:check_sizeof(params)
+    assert(type(params) == 'table', 'params must be a table')
+    assert(type(params.name) == 'string', 'params.name must be a string')
+    local ctype = params.name
 
     local objfile = tmpname() .. '.o'
     -- Encode the unique objfile path as decimal byte values so it can be
@@ -535,7 +540,7 @@ return (int)((char*)&$VARNAME - (char*)0);]]):gsub('%$([A-Z_]+)', {
     })
 
     local ok, err = self:compile({
-        headers = headers,
+        headers = params.headers,
         code = code,
         outfile = objfile,
     })

--- a/test/configh_test.lua
+++ b/test/configh_test.lua
@@ -83,7 +83,7 @@ function testcase.check_func()
     -- test that check whether the function is available
     local ok, err = cfgh:check_func('stdio.h', 'printf')
     assert(ok, err)
-    -- confirm that the entry is recorded in inspected.funcs keyed by fqname
+    -- confirm that the entry is recorded in inspected.funcs keyed by name
     assert.equal(cfgh.inspected.funcs['printf'].is_exists, true)
 
     -- test that probe without header includes returns false
@@ -99,7 +99,7 @@ function testcase.check_type()
     -- test that check whether the type is available
     local ok, err = cfgh:check_type('sys/socket.h', 'struct sockaddr_storage')
     assert(ok, err)
-    -- confirm that the entry is recorded in inspected.types keyed by fqname
+    -- confirm that the entry is recorded in inspected.types keyed by name
     assert.equal(cfgh.inspected.types['struct sockaddr_storage'].is_exists, true)
 
     -- test that probe without header includes returns false
@@ -116,7 +116,7 @@ function testcase.check_member()
     local ok, err = cfgh:check_member('sys/socket.h', 'struct sockaddr',
                                       'sa_family')
     assert(ok, err)
-    -- confirm that the entry is recorded in inspected.members keyed by fqname
+    -- confirm that the entry is recorded in inspected.members keyed by name
     assert.equal(cfgh.inspected.members['struct sockaddr.sa_family'].is_exists,
                  true)
 
@@ -136,7 +136,7 @@ function testcase.check_decl()
     -- test that check whether the macro constant is defined
     local ok, err = cfgh:check_decl('limits.h', 'PATH_MAX')
     assert(ok, err)
-    -- confirm that the entry is recorded in inspected.decls keyed by fqname
+    -- confirm that the entry is recorded in inspected.decls keyed by name
     assert.equal(cfgh.inspected.decls['PATH_MAX'].is_exists, true)
 
     -- test that add commented macro if the declaration is not available
@@ -180,9 +180,9 @@ function testcase.check_sizeof()
     assert.not_nil(unknown_entry)
     assert.equal(unknown_entry.is_exists, false)
 
-    -- test that throws an error if ctype is not string
+    -- test that throws an error if name is not string
     err = assert.throws(cfgh.check_sizeof, cfgh, nil, 123)
-    assert.match(err, 'ctype must be a string')
+    assert.match(err, 'name must be a string')
 end
 
 function testcase.output_status()
@@ -457,14 +457,12 @@ function testcase.inspected_mixed_table()
     local h = cfgh.inspected.headers['stdio.h']
     assert.equal(h, cfgh.inspected[1])
     assert.equal(h.target, 'headers')
-    assert.equal(h.declname, 'stdio.h')
-    assert.equal(h.order, 1)
+    assert.equal(h.name, 'stdio.h')
 
     local f = cfgh.inspected.funcs['printf']
     assert.equal(f, cfgh.inspected[2])
     assert.equal(f.target, 'funcs')
-    assert.equal(f.declname, 'printf')
-    assert.equal(f.order, 2)
+    assert.equal(f.name, 'printf')
 end
 
 function testcase.check_header_dedup()
@@ -473,7 +471,7 @@ function testcase.check_header_dedup()
     cfgh:check_header('stdio.h') -- re-probes and updates existing entry; no new integer entry
     assert.equal(#cfgh.inspected, 1)
 
-    -- check_func dedup: same fqname re-probes but adds no new integer entry
+    -- check_func dedup: same name re-probes but adds no new integer entry
     cfgh:check_func('stdio.h', 'printf')
     cfgh:check_func('stdio.h', 'printf') -- re-probe, no new entry
     assert.equal(#cfgh.inspected, 2)

--- a/test/executor_test.lua
+++ b/test/executor_test.lua
@@ -178,120 +178,178 @@ function testcase.check_header()
     local exec = executor('gcc')
 
     -- test that check whether the header is available
-    local ok, err = exec:check_header('stdio.h')
+    local ok, err = exec:check_header({
+        headers = 'stdio.h',
+    })
     assert.is_true(ok)
     assert.is_nil(err)
 
     -- test that return false if the header is not available
-    ok, err = exec:check_header('this_is_unknown_header_for_test.h')
+    ok, err = exec:check_header({
+        headers = 'this_is_unknown_header_for_test.h',
+    })
     assert.is_false(ok)
     assert.is_string(err)
 
-    -- test that throws an error if header argument is not string
-    err = assert.throws(exec.check_header, exec, 123)
-    assert.match(err, 'headers must be a string or string[]')
+    -- test that throws an error if params is not a table
+    err = assert.throws(exec.check_header, exec, 'stdio.h')
+    assert.match(err, 'params must be a table')
 
-    -- test that throws an error if headers contains non-string value
+    -- test that throws an error if params.headers is not string
     err = assert.throws(exec.check_header, exec, {
-        'stdio.h',
-        123,
+        headers = 123,
     })
-    assert.match(err, 'headers#2 must be a string')
+    assert.match(err, 'params.headers must be a string')
 end
 
 function testcase.check_func()
     local exec = executor('gcc')
 
     -- test that check whether the function is available
-    local ok, err = exec:check_func('stdio.h', 'printf')
+    local ok, err = exec:check_func({
+        headers = 'stdio.h',
+        name = 'printf',
+    })
     assert.is_true(ok)
     assert.is_nil(err)
 
-    -- test that return false if the function is not available
-    ok, err = exec:check_func(nil, 'printf')
+    -- test that return false if the function is not available (no headers)
+    ok, err = exec:check_func({
+        name = 'printf',
+    })
     assert.is_false(ok)
     assert.is_string(err)
 
-    -- test that throws an error if func argument is not string
-    err = assert.throws(exec.check_func, exec, 'stdio.h', 123)
-    assert.match(err, 'func must be a string')
+    -- test that throws an error if params is not a table
+    err = assert.throws(exec.check_func, exec, 'stdio.h')
+    assert.match(err, 'params must be a table')
+
+    -- test that throws an error if params.name is not string
+    err = assert.throws(exec.check_func, exec, {
+        headers = 'stdio.h',
+        name = 123,
+    })
+    assert.match(err, 'params.name must be a string')
 end
 
 function testcase.check_type()
     local exec = executor('gcc')
 
     -- test that check whether the type is available
-    local ok, err = exec:check_type('sys/socket.h', 'struct sockaddr_storage')
+    local ok, err = exec:check_type({
+        headers = 'sys/socket.h',
+        name = 'struct sockaddr_storage',
+    })
     assert.is_true(ok)
     assert.is_nil(err)
 
-    -- test that return false if the types is not available
-    ok, err = exec:check_type(nil, 'struct sockaddr_storage')
+    -- test that return false if the type is not available (no headers)
+    ok, err = exec:check_type({
+        name = 'struct sockaddr_storage',
+    })
     assert.is_false(ok)
     assert.is_string(err)
 
-    -- test that throws an error if type argument is not string
-    err = assert.throws(exec.check_type, exec, 'stdio.h', 123)
-    assert.match(err, 'type must be a string')
+    -- test that throws an error if params is not a table
+    err = assert.throws(exec.check_type, exec, 'sys/socket.h')
+    assert.match(err, 'params must be a table')
+
+    -- test that throws an error if params.name is not string
+    err = assert.throws(exec.check_type, exec, {
+        headers = 'stdio.h',
+        name = 123,
+    })
+    assert.match(err, 'params.name must be a string')
 end
 
 function testcase.check_member()
     local exec = executor('gcc')
 
     -- test that check whether the member field is available
-    local ok, err = exec:check_member('sys/socket.h', 'struct sockaddr',
-                                      'sa_family')
+    local ok, err = exec:check_member({
+        headers = 'sys/socket.h',
+        name = 'struct sockaddr',
+        member = 'sa_family',
+    })
     assert.is_true(ok)
     assert.is_nil(err)
 
     -- test that return false if the member field is not available
-    ok, err = exec:check_member('sys/socket.h', 'struct sockaddr',
-                                'unknown_member')
+    ok, err = exec:check_member({
+        headers = 'sys/socket.h',
+        name = 'struct sockaddr',
+        member = 'unknown_member',
+    })
     assert.is_false(ok)
     assert.is_string(err)
 
-    -- test that throws an error if type argument is not string
-    err = assert.throws(exec.check_member, exec, 'sys/socket.h', 123)
-    assert.match(err, 'type must be a string')
+    -- test that throws an error if params is not a table
+    err = assert.throws(exec.check_member, exec, 'sys/socket.h')
+    assert.match(err, 'params must be a table')
 
-    -- test that throws an error if member argument is not string
-    err = assert.throws(exec.check_member, exec, 'sys/socket.h',
-                        'struct sockaddr', 123)
-    assert.match(err, 'member must be a string')
+    -- test that throws an error if params.name is not string
+    err = assert.throws(exec.check_member, exec, {
+        headers = 'sys/socket.h',
+        name = 123,
+    })
+    assert.match(err, 'params.name must be a string')
+
+    -- test that throws an error if params.member is not string
+    err = assert.throws(exec.check_member, exec, {
+        headers = 'sys/socket.h',
+        name = 'struct sockaddr',
+        member = 123,
+    })
+    assert.match(err, 'params.member must be a string')
 end
 
 function testcase.check_sizeof()
     local exec = executor('gcc')
 
     -- test that returns the size of a primitive type
-    local ok, err, size = exec:check_sizeof(nil, 'char')
+    local ok, err, size = exec:check_sizeof({
+        name = 'char',
+    })
     assert.is_true(ok)
     assert.is_nil(err)
     assert.equal(size, 1)
 
     -- test that returns the correct size for int (typically 4)
-    ok, err, size = exec:check_sizeof(nil, 'int')
+    ok, err, size = exec:check_sizeof({
+        name = 'int',
+    })
     assert.is_true(ok)
     assert.is_nil(err)
     assert.is_number(size)
     assert.is_true(size > 0)
 
     -- test that returns size using a header type
-    ok, err, size = exec:check_sizeof('stddef.h', 'size_t')
+    ok, err, size = exec:check_sizeof({
+        headers = 'stddef.h',
+        name = 'size_t',
+    })
     assert.is_true(ok)
     assert.is_nil(err)
     assert.is_number(size)
     assert.is_true(size > 0)
 
-    -- test that returns nil for an unknown type
-    ok, err, size = exec:check_sizeof(nil, 'no_such_type_t')
+    -- test that returns false for an unknown type
+    ok, err, size = exec:check_sizeof({
+        name = 'no_such_type_t',
+    })
     assert.is_false(ok)
     assert.is_string(err)
     assert.is_nil(size)
 
-    -- test that throws an error if ctype argument is not string
-    err = assert.throws(exec.check_sizeof, exec, nil, 123)
-    assert.match(err, 'ctype must be a string')
+    -- test that throws an error if params is not a table
+    err = assert.throws(exec.check_sizeof, exec, 'char')
+    assert.match(err, 'params must be a table')
+
+    -- test that throws an error if params.name is not string
+    err = assert.throws(exec.check_sizeof, exec, {
+        name = 123,
+    })
+    assert.match(err, 'params.name must be a string')
 end
 
 function testcase.set_cppflags()
@@ -395,28 +453,47 @@ function testcase.check_decl()
     local exec = executor('gcc')
 
     -- test that check whether the macro constant is defined
-    local ok, err = exec:check_decl('limits.h', 'PATH_MAX')
+    local ok, err = exec:check_decl({
+        headers = 'limits.h',
+        name = 'PATH_MAX',
+    })
     assert.is_true(ok)
     assert.is_nil(err)
 
     -- test that check whether the enum value is defined
-    ok, err = exec:check_decl('fcntl.h', 'O_RDONLY')
+    ok, err = exec:check_decl({
+        headers = 'fcntl.h',
+        name = 'O_RDONLY',
+    })
     assert.is_true(ok)
     assert.is_nil(err)
 
     -- test that check whether the global variable is defined
-    ok, err = exec:check_decl('errno.h', 'errno')
+    ok, err = exec:check_decl({
+        headers = 'errno.h',
+        name = 'errno',
+    })
     assert.is_true(ok)
     assert.is_nil(err)
 
     -- test that return false if the declaration is not available
-    ok, err = exec:check_decl('limits.h', 'UNKNOWN_CONSTANT')
+    ok, err = exec:check_decl({
+        headers = 'limits.h',
+        name = 'UNKNOWN_CONSTANT',
+    })
     assert.is_false(ok)
     assert.is_string(err)
 
-    -- test that throws an error if name argument is not string
-    err = assert.throws(exec.check_decl, exec, 'stdio.h', 123)
-    assert.match(err, 'name must be a string')
+    -- test that throws an error if params is not a table
+    err = assert.throws(exec.check_decl, exec, 'stdio.h')
+    assert.match(err, 'params must be a table')
+
+    -- test that throws an error if params.name is not string
+    err = assert.throws(exec.check_decl, exec, {
+        headers = 'stdio.h',
+        name = 123,
+    })
+    assert.match(err, 'params.name must be a string')
 end
 
 function testcase.cppflags_env()
@@ -553,17 +630,23 @@ function testcase.incdirs_functional()
     hfile:close()
 
     -- test that check_header fails without incdirs set
-    local ok = exec:check_header('configh_custom_test.h')
+    local ok = exec:check_header({
+        headers = 'configh_custom_test.h',
+    })
     assert.is_false(ok)
 
     -- test that check_header succeeds after adding the dir
     exec:add_incdirs(tmpdir)
-    ok = exec:check_header('configh_custom_test.h')
+    ok = exec:check_header({
+        headers = 'configh_custom_test.h',
+    })
     assert.is_true(ok)
 
     -- test that check_header fails after clearing incdirs
     exec:set_incdirs({})
-    ok = exec:check_header('configh_custom_test.h')
+    ok = exec:check_header({
+        headers = 'configh_custom_test.h',
+    })
     assert.is_false(ok)
 
     -- cleanup


### PR DESCRIPTION
This pull request refactors the configuration probing API and its executor to consistently use a single `name` field as the identifier for all probes, replacing the previous use of `declname` and `fqname`. This change simplifies the API, clarifies documentation, and standardizes keying and display logic throughout the codebase and test suite. All probe methods and executor functions now accept a table with a `name` field, and the internal storage and output logic have been updated accordingly.

### API and Internal Data Model Simplification

* All probe methods (`check_header`, `check_func`, `check_type`, `check_decl`, `check_member`, `check_sizeof`) now require a `name` field as the identifier, replacing `declname` and `fqname`. The `name` is used as the hash key, display label, and macro base throughout. Internal storage in `inspected` tables is keyed by `name` (or `"name.member"` for struct members). [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L267-R276) [[2]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L287-L414)
* The executor methods (`check_header`, `check_func`, `check_type`, `check_decl`, `check_member`, `check_sizeof`) now accept a single table parameter containing `name` and other fields, rather than individual arguments. All internal assertions and code generation use `params.name`. [[1]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L424-R488) [[2]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L493-R504) [[3]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L538-R543)

### Output and Macro Generation

* Macro and comment generation in `Configh:flush` now uses `entry.name` for macro names and display, ensuring consistency and removing references to `fqname`.

### Documentation and Comments

* All function comments and parameter documentation have been updated to reflect the new API, clarifying the meaning of `name` and the expected structure of parameters. [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L267-R276) [[2]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L424-R488) [[3]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L493-R504)

### Test Suite Updates

* The test suite has been updated to use `name` as the key for all assertions, and test comments now refer to `name` instead of `fqname` or `declname`. Error messages and deduplication logic in tests have also been updated for clarity and accuracy. [[1]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748L86-R86) [[2]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748L102-R102) [[3]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748L119-R119) [[4]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748L139-R139) [[5]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748L183-R185) [[6]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748L460-R465) [[7]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748L476-R474)