### PR TITLE
Add library probe support to check_func

### DIFF
--- a/lib/configh.lua
+++ b/lib/configh.lua
@@ -62,6 +62,7 @@ function Configh:init(cc)
         decls = {},
         members = {},
         sizeof = {},
+        libs = {},
     }
     self.exec = executor(cc)
     self.output = false
@@ -133,6 +134,18 @@ function Configh:flush(pathname)
             lines[#lines + 1] = entry.is_exists and
                                     format('#define HAVE_%s 1', macro_name) or
                                     format('/* #undef HAVE_%s */', macro_name)
+            if entry.library then
+                local lib_macro = entry.library:upper():gsub('[^%w]', '_')
+                local lib_exists = self.inspected.libs[entry.library]
+                lines[#lines + 1] = format(
+                                        "/* Define to 1 if you have the `%s' library. */",
+                                        entry.library)
+                lines[#lines + 1] = lib_exists and
+                                        format('#define HAVE_LIB_%s 1',
+                                               lib_macro) or
+                                        format('/* #undef HAVE_LIB_%s */',
+                                               lib_macro)
+            end
         end
         lines[#lines + 1] = ''
     end
@@ -143,6 +156,7 @@ function Configh:flush(pathname)
         decls = {},
         members = {},
         sizeof = {},
+        libs = {},
     }
 
     -- output messages
@@ -272,7 +286,10 @@ local EXEC_METHOD = {
 ---                     display label, and HAVE_/SIZEOF_ macro base.
 ---                     For 'members', the stored key becomes "name.member".
 ---   member   string   member field name ('members' target only, required)
---- All other fields (headers, ...) are passed through to the executor
+---   library  string?  library name; the first probe for a given library
+---                     name sets entry.library so flush() emits HAVE_LIB_*
+---                     alongside the function macro.
+--- All other fields (headers, func, ...) are passed through to the executor
 --- without validation here; each executor method validates its own fields.
 --- @param self configh
 --- @param target string  'headers'|'funcs'|'types'|'decls'|'members'|'sizeof'
@@ -309,11 +326,27 @@ local function check(self, target, params)
 
     local entry = self.inspected[target][name]
     if not entry then
+        -- library dedup: only the first funcs probe for a given library name
+        -- carries entry.library so that flush() emits HAVE_LIB_* exactly once.
+        -- libs[library] stores the probe result so flush() uses it independently
+        -- of the function's entry.is_exists.
+        local library = params.library
+        if library then
+            local libs = self.inspected.libs
+            local is_first_link = libs[library] == nil
+            if not libs[library] then
+                libs[library] = ok
+            end
+            if not is_first_link then
+                library = nil
+            end
+        end
         entry = {
             target = target,
             name = name,
             is_exists = ok,
             member = target == 'members' and params.member or nil,
+            library = library,
         }
         self.inspected[target][name] = entry
         self.inspected[#self.inspected + 1] = entry
@@ -335,16 +368,22 @@ function Configh:check_header(header)
     })
 end
 
---- check_func check whether the function exists
+--- check_func check whether the function exists. When library is given, the
+--- link probe also uses -l<library>. The first probe for a given library
+--- name also emits a HAVE_LIB_<LIBRARY> macro in flush().
 --- @param headers string|string[]|nil  header files that declare the function
 --- @param name string  function name (e.g. "printf")
---- @return boolean ok true if the function exists
+--- @param library string?  optional library name to link (e.g. "m" for -lm)
+--- @return boolean ok true if the function (and library) exists
 --- @return string? err error message from the compiler
-function Configh:check_func(headers, name)
+function Configh:check_func(headers, name, library)
     assert(type(name) == 'string', 'name must be string')
+    assert(library == nil or type(library) == 'string',
+           'library must be string or nil')
     return check(self, 'funcs', {
         name = name,
         headers = headers,
+        library = library,
     })
 end
 

--- a/lib/executor.lua
+++ b/lib/executor.lua
@@ -215,6 +215,7 @@ function Executor:link(opts)
         concat(self.ldflags, ' '),
         flags_flatten(self.libdirs, '-L'),
         flags_flatten(self.libs, '-l'),
+        flags_flatten(opts.extra_libs or {}, '-l'),
         '2>',
         self.buffile,
     }, ' ')
@@ -433,16 +434,22 @@ function Executor:check_header(params)
 end
 
 --- check_func check the function is available
---- @param params table  { headers: string|string[]|nil, name: string }
+--- @param params table  { headers: string|string[]|nil, name: string, library: string? }
+---                      library is the name passed to -l (e.g. "m" for -lm)
 --- @return boolean ok
 --- @return string? err
 function Executor:check_func(params)
     assert(type(params) == 'table', 'params must be a table')
     assert(type(params.name) == 'string', 'params.name must be a string')
+    assert(params.library == nil or type(params.library) == 'string',
+           'params.library must be a string or nil')
     return self:link({
         headers = params.headers,
         code = format('void (*function_pointer)(void) = (void (*)(void))%s;',
                       params.name),
+        extra_libs = params.library and {
+            params.library,
+        } or {},
     })
 end
 

--- a/test/configh_test.lua
+++ b/test/configh_test.lua
@@ -185,6 +185,49 @@ function testcase.check_sizeof()
     assert.match(err, 'name must be a string')
 end
 
+function testcase.check_func_with_library()
+    local cfgh = configh('gcc')
+
+    -- test that check_func with library records func entry with library field
+    local ok, err = cfgh:check_func({
+        'math.h',
+    }, 'sin', 'm')
+    assert.is_true(ok)
+    assert.is_nil(err)
+    -- confirm func entry has library field set
+    local func_entry = cfgh.inspected.funcs['sin']
+    assert.not_nil(func_entry)
+    assert.equal(func_entry.is_exists, true)
+    assert.equal(func_entry.library, 'm')
+    -- confirm dedup sentinel is registered
+    assert.equal(cfgh.inspected.libs['m'], true)
+
+    -- test that dedup: second probe with same library clears entry.library
+    cfgh:check_func({
+        'math.h',
+    }, 'cos', 'm')
+    local cos_entry = cfgh.inspected.funcs['cos']
+    assert.not_nil(cos_entry)
+    assert.is_nil(cos_entry.library)
+    -- dedup sentinel unchanged
+    assert.equal(cfgh.inspected.libs['m'], true)
+
+    -- test that returns false for a nonexistent library
+    ok, err = cfgh:check_func(nil, 'no_such_func_xyz',
+                              'no_such_lib_xyz_for_test')
+    assert.is_false(ok)
+    assert.is_string(err)
+    local bad_entry = cfgh.inspected.funcs['no_such_func_xyz']
+    assert.not_nil(bad_entry)
+    assert.equal(bad_entry.library, 'no_such_lib_xyz_for_test')
+
+    -- test that throws an error if library is not string or nil
+    err = assert.throws(cfgh.check_func, cfgh, {
+        'math.h',
+    }, 'sin', 123)
+    assert.match(err, 'library must be string or nil')
+end
+
 function testcase.output_status()
     local cfgh = configh('gcc')
     local stdout = assert(io.tmpfile())
@@ -418,6 +461,8 @@ function testcase.flush()
     assert(cfgh:check_func('stdio.h', 'printf'))
     assert(cfgh:check_sizeof(nil, 'char'))
     cfgh:check_sizeof(nil, 'no_such_type_t')
+    assert(cfgh:check_func('math.h', 'sin', 'm'))
+    cfgh:check_func(nil, 'no_such_func_xyz', 'no_such_lib_xyz_for_test')
 
     -- test that check whether the function is available
     local ok, err = cfgh:flush('./test_config.h')
@@ -434,6 +479,8 @@ function testcase.flush()
         '\n#define HAVE_PRINTF 1\n',
         '\n#define SIZEOF_CHAR 1\n',
         '\n/* #undef SIZEOF_NO_SUCH_TYPE_T */\n',
+        '\n#define HAVE_LIB_M 1\n',
+        '\n/* #undef HAVE_LIB_NO_SUCH_LIB_XYZ_FOR_TEST */\n',
     }) do
         assert.match(content, pattern)
     end

--- a/test/executor_test.lua
+++ b/test/executor_test.lua
@@ -230,6 +230,31 @@ function testcase.check_func()
         name = 123,
     })
     assert.match(err, 'params.name must be a string')
+
+    -- test that check with a library links against it
+    ok, err = exec:check_func({
+        headers = 'math.h',
+        name = 'sin',
+        library = 'm',
+    })
+    assert.is_true(ok)
+    assert.is_nil(err)
+
+    -- test that returns false when the library does not exist
+    ok, err = exec:check_func({
+        name = 'no_such_func_xyz',
+        library = 'no_such_lib_xyz_for_test',
+    })
+    assert.is_false(ok)
+    assert.is_string(err)
+
+    -- test that throws an error if params.library is not string or nil
+    err = assert.throws(exec.check_func, exec, {
+        headers = 'stdio.h',
+        name = 'printf',
+        library = 123,
+    })
+    assert.match(err, 'params.library must be a string or nil')
 end
 
 function testcase.check_type()


### PR DESCRIPTION
This pull request adds support for checking if a specific library is available when probing for functions, and ensures that configuration headers define macros indicating the presence of those libraries. It introduces deduplication logic so that each library macro is defined only once, even if multiple functions are checked in the same library. The changes are covered by new and updated tests.

**Library checking and macro generation:**

* Added a `libs` table to `Configh`'s state to track probed libraries and deduplicate macro emission. Now, when a function is checked with a `library` parameter, a corresponding `HAVE_LIB_<LIBRARY>` macro is emitted in the generated config header, but only once per library. (`lib/configh.lua` [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R65) [[2]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R159) [[3]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R137-R148) [[4]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861R329-R349)
* Updated `Configh:check_func` and `Executor:check_func` to accept an optional `library` parameter, linking against the specified library during the probe and passing this information through the probe chain. (`lib/configh.lua` [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L338-R386) `lib/executor.lua` [[2]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L436-R452) [[3]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3R218)

**Documentation improvements:**

* Expanded documentation for `check_func` and related internal APIs to clarify the purpose and use of the new `library` parameter and macro generation logic. (`lib/configh.lua` [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L275-R292) [[2]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L338-R386) `lib/executor.lua` [[3]](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3L436-R452)

**Testing enhancements:**

* Added comprehensive tests to verify that `check_func` with the `library` parameter records entries correctly, deduplicates macro emission, and handles error cases for invalid libraries. Also updated flush tests to confirm that the correct macros are generated. (`test/configh_test.lua` [[1]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748R188-R230) [[2]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748R464-R465) [[3]](diffhunk://#diff-7ff9714363b7d58fd5d8756b40a28161c9e54d5a09b74059e5f3e6a05dcad748R482-R483)
* Extended executor tests to ensure that linking against libraries works as expected and that type validation for the `library` parameter is enforced. (`test/executor_test.lua` [test/executor_test.luaR233-R257](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0R233-R257))