### PR TITLE
Add configh.generate module

### DIFF
--- a/.luacov
+++ b/.luacov
@@ -5,5 +5,6 @@ modules = {
     ["configh"] = "lib/configh.lua",
     ["configh.command"] = "lib/command.lua",
     ["configh.executor"] = "lib/executor.lua",
+    ["configh.generate"] = "lib/generate.lua",
     ["configh.sortiter"] = "lib/sortiter.lua",
 }

--- a/.luacov
+++ b/.luacov
@@ -5,4 +5,5 @@ modules = {
     ["configh"] = "lib/configh.lua",
     ["configh.command"] = "lib/command.lua",
     ["configh.executor"] = "lib/executor.lua",
+    ["configh.sortiter"] = "lib/sortiter.lua",
 }

--- a/README.md
+++ b/README.md
@@ -216,9 +216,80 @@ The generated `config.h` file looks like this:
 
 ## Library API
 
-The `configh` module provides an API to generate a config.h file programmatically.
+The `configh` module provides two usage patterns: a declarative high-level
+function `configh.generate()` and a manual instance API.
 
-### Usage
+### Using configh.generate()
+
+The `configh.generate` module provides a `generate()` function that accepts
+a single cfg table and runs all probes in one call, then writes the result
+to `cfg.output`.
+
+```lua
+local generate = require('configh.generate')
+local report, err = generate({
+    -- C compiler name (optional, default: $CC)
+    cc = 'gcc',
+
+    -- output file path (required)
+    output = 'src/config.h',
+
+    -- enable status output (optional, default: false)
+    output_status = true,
+
+    -- compiler/linker settings (optional)
+    incdirs  = {'/usr/local/include'},
+    libdirs  = {'/usr/local/lib'},
+    libs     = {'z'},
+    cppflags = {'-D_GNU_SOURCE'},
+    cflags   = {'-std=c11'},
+    ldflags  = {'-Wl,-rpath,/usr/local/lib'},
+
+    -- feature macros (optional, mixed table)
+    features = {
+        _GNU_SOURCE = 1,
+        'ENABLE_FEATURE_X',
+    },
+
+    -- headers to check (optional)
+    headers = {'stdio.h', 'stdlib.h'},
+
+    -- functions to check per header (optional)
+    funcs = {
+        ['sys/epoll.h'] = {'epoll_create', 'epoll_create1'},
+    },
+
+    -- types to check per header (optional)
+    types = {
+        ['sys/types.h'] = {'pid_t', 'size_t'},
+    },
+
+    -- declarations to check per header (optional)
+    decls = {
+        ['unistd.h'] = {'STDIN_FILENO', 'STDOUT_FILENO'},
+    },
+
+    -- type sizes to measure per header (optional)
+    sizeof = {
+        ['sys/types.h'] = {'size_t', 'off_t'},
+    },
+
+    -- struct members to check per header (optional)
+    members = {
+        ['stdio.h'] = {
+            FILE = {'_flags'},
+        },
+    },
+})
+if report == nil then
+    error(err)
+end
+-- report['stdio.h'].is_exists            => true/false (header probed)
+-- report['sys/epoll.h'].epoll_create     => true/false (func found/not found)
+-- report['sys/types.h']['size_t']        => integer (byte size) or false
+```
+
+### Using the instance API
 
 ```lua
 local configh = require('configh')
@@ -295,6 +366,67 @@ if not ok then
     return
 end
 ```
+
+
+## report, err = generate( cfg [, label] )
+
+`require('configh.generate')` returns this function.
+
+Creates a `configh` instance, applies all settings from `cfg`, runs all
+probes, and flushes the result to `cfg.output`. This is the recommended
+entry point when all probe information is known up front.
+
+**Parameters**
+
+- `cfg:table`: configuration table with the following fields:
+  - `cc:string?`: C compiler name. Defaults to the `CC` environment variable.
+  - `output:string`: output path for the generated `config.h` file. **Required.**
+  - `output_status:boolean?`: enable status output to stdout (default: `false`).
+  - `incdirs:string|string[]?`: include directories (passed as `-I` flags).
+  - `libdirs:string|string[]?`: library search directories (passed as `-L` flags).
+  - `libs:string|string[]?`: library names to link against (passed as `-l` flags).
+  - `cppflags:string|string[]?`: extra preprocessor flags.
+  - `cflags:string|string[]?`: extra compiler flags.
+  - `ldflags:string|string[]?`: extra linker flags.
+  - `features:table?`: feature macros. Mixed table: string keys define named
+    macros with a value; integer-keyed strings define macros without a value.
+  - `headers:string[]?`: header files to probe with `check_header`.
+  - `funcs:table<string,string[]>?`: functions to probe per header file.
+    Format: `{ [header] = { func, ... } }`.
+  - `types:table<string,string[]>?`: C types to probe per header file.
+    Format: `{ [header] = { type, ... } }`.
+  - `decls:table<string,string[]>?`: declarations to probe per header file.
+    Format: `{ [header] = { decl, ... } }`.
+  - `sizeof:table<string,string[]>?`: type sizes to measure per header file.
+    Format: `{ [header] = { type, ... } }`.
+  - `members:table<string,table<string,string[]>>?`: struct members to probe.
+    Format: `{ [header] = { [type] = { member, ... } } }`.
+- `label:string?`: root label used in error messages (default: `'cfg'`).
+  Typically set to the module name (e.g. `build.modules` key) when called
+  from `luarocks-build-hooks`.
+
+**Returns**
+
+- `report:table`: probe result table on success.
+  - `report[header].is_exists:boolean`: whether the header was found.
+  - `report[header][name]:boolean`: `true`/`false` for each `funcs`, `types`,
+    or `decls` probe.
+  - `report[header]["type.member"]:boolean`: `true`/`false` for each `members`
+    probe. The key is `"ctype.member"` (e.g. `"FILE._flags"`).
+  - `report[header][name]:integer`: byte size for each `sizeof` probe, or
+    `false` if the type was not found.
+- `err:string?`: error message if `cfg.output` could not be written
+  (`report` is `nil` in this case).
+
+**NOTE**
+
+- `check_header` deduplication is applied automatically: a header that appears
+  in both `headers` and as a key in `funcs`/`types`/`decls`/`sizeof`/`members`
+  is compiled only once.
+- `funcs` always calls `check_func(header, name)` without a per-function
+  library argument. Use `cfg.libs` to set global link libraries for all probes,
+  or use the instance API (`configh:check_func`) for per-function library
+  control.
 
 
 ## cfgh = configh( cc )
@@ -488,7 +620,7 @@ Checks whether the specified header file exists.
 **Returns**
 
 - `ok:boolean`: `true` on success, or `false` on failure.
-- `err:string`: error message if the generated source code fails to compile.
+- `err:string?`: error message if the generated source code fails to compile.
 
 
 ## ok, err = configh:check_func( headers, name [, library] )
@@ -504,7 +636,7 @@ Checks whether the specified function exists.
 **Returns**
 
 - `ok:boolean`: `true` on success, or `false` on failure.
-- `err:string`: error message if the generated source code fails to compile or link.
+- `err:string?`: error message if the generated source code fails to compile or link.
 
 
 ## ok, err = configh:check_type( headers, name )
@@ -519,7 +651,7 @@ Checks whether the specified type exists.
 **Returns**
 
 - `ok:boolean`: `true` on success, or `false` on failure.
-- `err:string`: error message if the generated source code fails to compile.
+- `err:string?`: error message if the generated source code fails to compile.
 
 
 ## ok, err = configh:check_decl( headers, name )
@@ -534,7 +666,7 @@ Checks whether the specified declaration (macro constant, enum value, or global 
 **Returns**
 
 - `ok:boolean`: `true` on success, or `false` on failure.
-- `err:string`: error message if the generated source code fails to compile.
+- `err:string?`: error message if the generated source code fails to compile.
 
 
 ## ok, err = configh:check_member( headers, name, member )
@@ -550,7 +682,7 @@ Checks whether the specified member field exists in the type.
 **Returns**
 
 - `ok:boolean`: `true` on success, or `false` on failure.
-- `err:string`: error message if the generated source code fails to compile.
+- `err:string?`: error message if the generated source code fails to compile.
 
 
 ## ok, err, size = configh:check_sizeof( headers, name )
@@ -586,7 +718,7 @@ Flushes the definition macros to the specified pathname.
 **Returns**
 
 - `ok:boolean`: `true` on success, or `false` on failure.
-- `err:string`: error message if the file failed to be written.
+- `err:string?`: error message if the file failed to be written.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -278,10 +278,13 @@ end
 
 -- check the size of a C type at compile time.
 -- SIZEOF_<TYPE> macro is emitted in config.h on success.
-ok, err = cfgh:check_sizeof('sys/types.h', 'size_t')
+local sz
+ok, err, sz = cfgh:check_sizeof('sys/types.h', 'size_t')
 if not ok then
     print('size_t not found')
     print(err)
+else
+    print('size_t = ' .. sz .. ' bytes')
 end
 
 -- flush the definition macros to the specified pathname.
@@ -550,7 +553,7 @@ Checks whether the specified member field exists in the type.
 - `err:string`: error message if the generated source code fails to compile.
 
 
-## ok, err = configh:check_sizeof( headers, name )
+## ok, err, size = configh:check_sizeof( headers, name )
 
 Determines the size of a C type at compile time.
 
@@ -562,7 +565,8 @@ Determines the size of a C type at compile time.
 **Returns**
 
 - `ok:boolean`: `true` on success, or `false` on failure.
-- `err:string`: error message if the generated source code fails to compile.
+- `err:string?`: error message if the generated source code fails to compile.
+- `size:integer?`: byte size of the type on success, `nil` on failure.
 
 **NOTE**
 

--- a/lib/configh.lua
+++ b/lib/configh.lua
@@ -353,7 +353,7 @@ local function check(self, target, params)
     end
     entry.is_exists = ok
     entry.size = target == 'sizeof' and extra or nil
-    return ok, err
+    return ok, err, extra
 end
 
 --- check_header check whether the header file exists
@@ -430,12 +430,12 @@ function Configh:check_member(headers, name, member)
 end
 
 --- check_sizeof determines the size of a C type at compile time and records
---- the result in inspected.sizeof. The size can be read back via
---- inspected.sizeof[name].size after a successful call.
+--- the result in inspected.sizeof.
 --- @param headers string|string[]|nil  header files that declare the type
 --- @param name string  C type name (e.g. "size_t", "struct sockaddr")
 --- @return boolean ok
 --- @return string? err
+--- @return integer? size  byte size of the type on success, nil otherwise
 function Configh:check_sizeof(headers, name)
     assert(type(name) == 'string', 'name must be a string')
     return check(self, 'sizeof', {

--- a/lib/generate.lua
+++ b/lib/generate.lua
@@ -1,0 +1,252 @@
+--
+-- Copyright (C) 2026 Masatoshi Fukunaga
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+--
+local assert = assert
+local pairs = pairs
+local type = type
+local configh = require('configh')
+local sort = require('configh.sortiter')
+
+local sortedkpairs = sort.kpairs
+local sortedipairs = sort.ipairs
+local sortedpairs = sort.pairs
+
+local VALID_CFG_KEYS = {
+    cc = true,
+    output = true,
+    output_status = true,
+    incdirs = true,
+    libdirs = true,
+    libs = true,
+    cppflags = true,
+    cflags = true,
+    ldflags = true,
+    features = true,
+    headers = true,
+    funcs = true,
+    types = true,
+    decls = true,
+    members = true,
+    sizeof = true,
+}
+
+--- ensure_header checks a header exactly once and records the result in
+--- report[header]. Subsequent calls return the cached is_exists value
+--- without re-running the probe (cfgh:check_header also deduplicates
+--- internally, but this avoids the extra call entirely).
+--- @param cfgh configh
+--- @param report table
+--- @param header string
+--- @return boolean ok
+local function ensure_header(cfgh, report, header)
+    if report[header] then
+        return report[header].is_exists
+    end
+    local ok = cfgh:check_header(header)
+    report[header] = {
+        is_exists = ok,
+    }
+    return ok
+end
+
+--- probe_headers ensures every header listed in cfg.headers is probed and
+--- recorded in report.
+--- @param cfgh configh
+--- @param report table
+--- @param label string
+--- @param cfg table
+local function probe_headers(cfgh, report, label, cfg)
+    for _, header in sortedipairs(label, cfg, 'headers') do
+        ensure_header(cfgh, report, header)
+    end
+end
+
+--- probe_funcs probes each function under its header.  A header that does not
+--- exist is skipped; its child entries are left as nil.
+--- report[header][name] = true if the function is found, false otherwise.
+--- @param cfgh configh
+--- @param report table
+--- @param label string
+--- @param cfg table
+local function probe_funcs(cfgh, report, label, cfg)
+    for header in sortedkpairs(label, cfg, 'funcs') do
+        if ensure_header(cfgh, report, header) then
+            for _, name in sortedipairs(label, cfg, 'funcs', header) do
+                report[header][name] = cfgh:check_func(header, name) == true
+            end
+        end
+    end
+end
+
+--- probe_types probes each C type under its header.
+--- report[header][name] = true if the type is found, false otherwise.
+--- @param cfgh configh
+--- @param report table
+--- @param label string
+--- @param cfg table
+local function probe_types(cfgh, report, label, cfg)
+    for header in sortedkpairs(label, cfg, 'types') do
+        if ensure_header(cfgh, report, header) then
+            for _, name in sortedipairs(label, cfg, 'types', header) do
+                report[header][name] = cfgh:check_type(header, name) == true
+            end
+        end
+    end
+end
+
+--- probe_decls probes each preprocessor constant/declaration under its header.
+--- report[header][name] = true if the declaration is found, false otherwise.
+--- @param cfgh configh
+--- @param report table
+--- @param label string
+--- @param cfg table
+local function probe_decls(cfgh, report, label, cfg)
+    for header in sortedkpairs(label, cfg, 'decls') do
+        if ensure_header(cfgh, report, header) then
+            for _, name in sortedipairs(label, cfg, 'decls', header) do
+                report[header][name] = cfgh:check_decl(header, name) == true
+            end
+        end
+    end
+end
+
+--- probe_sizeof probes the byte size of each C type under its header.
+--- report[header][name] = size:integer if the type is found, false otherwise.
+--- The size value is read back from inspected.sizeof[name].size which
+--- check_sizeof records internally after a successful compile.
+--- @param cfgh configh
+--- @param report table
+--- @param label string
+--- @param cfg table
+local function probe_sizeof(cfgh, report, label, cfg)
+    for header in sortedkpairs(label, cfg, 'sizeof') do
+        if ensure_header(cfgh, report, header) then
+            for _, name in sortedipairs(label, cfg, 'sizeof', header) do
+                local ok, _, size = cfgh:check_sizeof(header, name)
+                report[header][name] = ok and size or false
+            end
+        end
+    end
+end
+
+--- probe_members probes each struct/union member under its header.
+--- report[header]["ctype.member"] = true if the member is found, false
+--- otherwise.
+--- @param cfgh configh
+--- @param report table
+--- @param label string
+--- @param cfg table
+local function probe_members(cfgh, report, label, cfg)
+    for header in sortedkpairs(label, cfg, 'members') do
+        if ensure_header(cfgh, report, header) then
+            for ctype in sortedkpairs(label, cfg, 'members', header) do
+                for _, member in sortedipairs(label, cfg, 'members', header,
+                                              ctype) do
+                    report[header][ctype .. '.' .. member] = cfgh:check_member(
+                                                                 header, ctype,
+                                                                 member) == true
+                end
+            end
+        end
+    end
+end
+
+--- generate creates a new Configh instance, runs all probes described in cfg,
+--- and flushes the result to cfg.output.
+--- @param cfg table
+--- @param label string?  root label for error messages (default: 'cfg')
+--- @return table? report
+--- @return string? err
+local function generate(cfg, label)
+    label = label or 'cfg'
+    assert(type(label) == 'string', 'label must be a string')
+    assert(type(cfg) == 'table', label .. ' must be a table')
+    assert(type(cfg.output) == 'string', label .. '.output must be a string')
+    for k in pairs(cfg) do
+        assert(VALID_CFG_KEYS[k], label .. ': unknown key: ' .. tostring(k))
+    end
+    -- validate probe field structure before creating cfgh instance so that
+    -- structure errors are reported before cc/CC validation errors
+    for _, key in ipairs({
+        'features',
+        'headers',
+        'funcs',
+        'types',
+        'decls',
+        'sizeof',
+        'members',
+    }) do
+        if cfg[key] ~= nil and type(cfg[key]) ~= 'table' then
+            error(label .. '["' .. key .. '"] must be a table')
+        end
+    end
+
+    local cfgh = configh(cfg.cc)
+
+    if cfg.output_status ~= nil then
+        cfgh:output_status(cfg.output_status)
+    end
+    if cfg.incdirs ~= nil then
+        cfgh:set_incdirs(cfg.incdirs)
+    end
+    if cfg.libdirs ~= nil then
+        cfgh:set_libdirs(cfg.libdirs)
+    end
+    if cfg.libs ~= nil then
+        cfgh:set_libs(cfg.libs)
+    end
+    if cfg.cppflags ~= nil then
+        cfgh:set_cppflags(cfg.cppflags)
+    end
+    if cfg.cflags ~= nil then
+        cfgh:set_cflags(cfg.cflags)
+    end
+    if cfg.ldflags ~= nil then
+        cfgh:set_ldflags(cfg.ldflags)
+    end
+
+    -- features: mixed table (string key = name+value, integer key = name only)
+    -- sortedpairs ensures only string/integer keys are present, so the type(k)
+    -- branch here is a semantic distinction, not an error guard.
+    for k, v in sortedpairs(label, cfg, 'features') do
+        if type(k) == 'string' then
+            cfgh:set_feature(k, v)
+        else
+            cfgh:set_feature(v)
+        end
+    end
+
+    local report = {}
+    probe_headers(cfgh, report, label, cfg)
+    probe_funcs(cfgh, report, label, cfg)
+    probe_types(cfgh, report, label, cfg)
+    probe_decls(cfgh, report, label, cfg)
+    probe_sizeof(cfgh, report, label, cfg)
+    probe_members(cfgh, report, label, cfg)
+
+    local ok, err = cfgh:flush(cfg.output)
+    if not ok then
+        return nil, err
+    end
+    return report
+end
+
+return generate

--- a/lib/sortiter.lua
+++ b/lib/sortiter.lua
@@ -1,0 +1,165 @@
+--
+-- Copyright (C) 2026 Masatoshi Fukunaga
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+--
+local pairs = pairs
+local sort = table.sort
+
+local function EMPTY_ITER()
+end
+
+--- get_value follows a field path through tbl, returning the target table and
+--- the accumulated label path for use in error messages.
+--- Returns nil if any step along the path is nil (target does not exist).
+--- Errors if any non-nil step is not a table.
+--- @param label string  root label for error messages
+--- @param tbl table     root table
+--- @param fields table  ordered list of field names to follow
+--- @return table|nil t
+--- @return string path
+local function get_value(label, tbl, fields)
+    local t = tbl
+    local path = label
+    for i = 1, #fields do
+        local f = fields[i]
+        local v = t[f]
+        if v == nil then
+            return nil, path
+        end
+        path = path .. '["' .. tostring(f) .. '"]'
+        if type(v) ~= 'table' then
+            error(path .. ' must be a table')
+        end
+        t = v
+    end
+    return t, path
+end
+
+--- sortedkpairs iterates the table reached by following fields from tbl,
+--- yielding string keys in sorted order. Errors if any key is not a string.
+--- @param label string  root label for error messages
+--- @param tbl table     root table
+--- @param ... string    field path to follow
+--- @return function iter
+local function sortedkpairs(label, tbl, ...)
+    local t, path = get_value(label, tbl, {
+        ...,
+    })
+    if not t then
+        return EMPTY_ITER
+    end
+    local arr = {}
+    for k, v in pairs(t) do
+        if type(k) ~= 'string' then
+            error(path .. ' keys must be string')
+        end
+        arr[#arr + 1] = {
+            k = k,
+            v = v,
+        }
+    end
+    sort(arr, function(a, b)
+        return a.k < b.k
+    end)
+    local i = 0
+    return function()
+        i = i + 1
+        local e = arr[i]
+        if e then
+            return e.k, e.v
+        end
+    end
+end
+
+--- sortedipairs iterates the table reached by following fields from tbl in
+--- integer-index order (1, 2, ...). Errors if any key is not an integer.
+--- @param label string  root label for error messages
+--- @param tbl table     root table
+--- @param ... string    field path to follow
+--- @return function iter
+local function sortedipairs(label, tbl, ...)
+    local t, path = get_value(label, tbl, {
+        ...,
+    })
+    if not t then
+        return EMPTY_ITER
+    end
+    for k in pairs(t) do
+        if type(k) ~= 'number' or k % 1 ~= 0 then
+            error(path .. ' keys must be integer')
+        end
+    end
+    local i = 0
+    return function()
+        i = i + 1
+        local v = t[i]
+        if v ~= nil then
+            return i, v
+        end
+    end
+end
+
+--- sortedpairs iterates the table reached by following fields from tbl,
+--- yielding string keys first (sorted), then integer keys (sorted). Errors if
+--- any key is neither a string nor an integer.
+--- @param label string  root label for error messages
+--- @param tbl table     root table
+--- @param ... string    field path to follow
+--- @return function iter
+local function sortedpairs(label, tbl, ...)
+    local t, path = get_value(label, tbl, {
+        ...,
+    })
+    if not t then
+        return EMPTY_ITER
+    end
+    local arr = {}
+    for k, v in pairs(t) do
+        local kt = type(k)
+        if kt ~= 'string' and not (kt == 'number' and k % 1 == 0) then
+            error(path .. ' keys must be string or integer')
+        end
+        arr[#arr + 1] = {
+            t = kt,
+            k = k,
+            v = v,
+        }
+    end
+    sort(arr, function(a, b)
+        if a.t == b.t then
+            return a.k < b.k
+        end
+        return a.t == 'string' -- string keys before integer keys
+    end)
+    local i = 0
+    return function()
+        i = i + 1
+        local e = arr[i]
+        if e then
+            return e.k, e.v
+        end
+    end
+end
+
+return {
+    kpairs = sortedkpairs,
+    ipairs = sortedipairs,
+    pairs = sortedpairs,
+}

--- a/rockspecs/configh-dev-1.rockspec
+++ b/rockspecs/configh-dev-1.rockspec
@@ -28,6 +28,7 @@ build = {
         ["configh"] = "lib/configh.lua",
         ["configh.command"] = "lib/command.lua",
         ["configh.executor"] = "lib/executor.lua",
+        ["configh.generate"] = "lib/generate.lua",
         ["configh.sortiter"] = "lib/sortiter.lua",
     },
 }

--- a/rockspecs/configh-dev-1.rockspec
+++ b/rockspecs/configh-dev-1.rockspec
@@ -28,5 +28,6 @@ build = {
         ["configh"] = "lib/configh.lua",
         ["configh.command"] = "lib/command.lua",
         ["configh.executor"] = "lib/executor.lua",
+        ["configh.sortiter"] = "lib/sortiter.lua",
     },
 }

--- a/test/configh_test.lua
+++ b/test/configh_test.lua
@@ -150,9 +150,10 @@ function testcase.check_sizeof()
     local cfgh = configh('gcc')
 
     -- test that returns true for a known type
-    local ok, err = cfgh:check_sizeof(nil, 'char')
+    local ok, err, size = cfgh:check_sizeof(nil, 'char')
     assert.is_true(ok)
     assert.is_nil(err)
+    assert.equal(size, 1)
     -- confirm that the entry is recorded in inspected.sizeof keyed by type name
     local entry = cfgh.inspected.sizeof['char']
     assert.not_nil(entry)
@@ -160,9 +161,10 @@ function testcase.check_sizeof()
     assert.equal(entry.size, 1)
 
     -- test that records the correct size for size_t with header
-    ok, err = cfgh:check_sizeof('stddef.h', 'size_t')
+    ok, err, size = cfgh:check_sizeof('stddef.h', 'size_t')
     assert.is_true(ok)
     assert.is_nil(err)
+    assert.is_true(size > 0)
     local size_t_entry = cfgh.inspected.sizeof['size_t']
     assert.not_nil(size_t_entry)
     assert.is_true(size_t_entry.size > 0)
@@ -172,10 +174,11 @@ function testcase.check_sizeof()
     cfgh:check_sizeof(nil, 'char')
     assert.equal(cfgh.inspected.sizeof['char'], entry_first)
 
-    -- test that returns false for an unknown type
-    ok, err = cfgh:check_sizeof(nil, 'no_such_type_t')
+    -- test that returns false for an unknown type (size is nil)
+    ok, err, size = cfgh:check_sizeof(nil, 'no_such_type_t')
     assert.is_false(ok)
     assert.is_string(err)
+    assert.is_nil(size)
     local unknown_entry = cfgh.inspected.sizeof['no_such_type_t']
     assert.not_nil(unknown_entry)
     assert.equal(unknown_entry.is_exists, false)

--- a/test/configh_test.lua
+++ b/test/configh_test.lua
@@ -16,11 +16,15 @@ function testcase.new_configh()
     setenv('CC', nil)
 
     -- test that throws an error if cc is not string
-    local err = assert.throws(configh, 123)
+    local err = assert.throws(function()
+        configh(123)
+    end)
     assert.match(err, 'cc must be string or nil')
 
     -- test that throws an error if cc and CC environment variable are not set
-    err = assert.throws(configh)
+    err = assert.throws(function()
+        configh()
+    end)
     assert.match(err,
                  'cc argument or CC environment variable must contain compiler name')
 end
@@ -515,15 +519,4 @@ function testcase.inspected_mixed_table()
     assert.equal(f.name, 'printf')
 end
 
-function testcase.check_header_dedup()
-    local cfgh = configh('gcc')
-    cfgh:check_header('stdio.h')
-    cfgh:check_header('stdio.h') -- re-probes and updates existing entry; no new integer entry
-    assert.equal(#cfgh.inspected, 1)
-
-    -- check_func dedup: same name re-probes but adds no new integer entry
-    cfgh:check_func('stdio.h', 'printf')
-    cfgh:check_func('stdio.h', 'printf') -- re-probe, no new entry
-    assert.equal(#cfgh.inspected, 2)
-end
 

--- a/test/generate_test.lua
+++ b/test/generate_test.lua
@@ -1,0 +1,299 @@
+require('luacov')
+local testcase = require('testcase')
+local assert = require('assert')
+local generate = require('configh.generate')
+
+function testcase.generate_validates_cfg()
+    -- test that throws error if cfg is not a table
+    local err = assert.throws(generate, 'not a table')
+    assert.match(err, 'cfg must be a table')
+
+    -- test that throws error if cfg.output is not a string
+    err = assert.throws(generate, {})
+    assert.match(err, '.output must be a string')
+
+    err = assert.throws(generate, {
+        output = 123,
+    })
+    assert.match(err, '.output must be a string')
+
+    -- test that throws error for unknown keys
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        unknown = 1,
+    })
+    assert.match(err, 'unknown key')
+
+    -- test that label is used in error messages
+    err = assert.throws(generate, {
+        output = 123,
+    }, 'mymodule')
+    assert.match(err, 'mymodule.output must be a string')
+end
+
+function testcase.generate_validates_structure()
+    -- test that throws error if a probe field is not a table
+    local err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        features = 'bad',
+    })
+    assert.match(err, '["features"] must be a table')
+
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        headers = 'bad',
+    })
+    assert.match(err, '["headers"] must be a table')
+
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        funcs = 'bad',
+    })
+    assert.match(err, '["funcs"] must be a table')
+
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        types = 'bad',
+    })
+    assert.match(err, '["types"] must be a table')
+
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        decls = 'bad',
+    })
+    assert.match(err, '["decls"] must be a table')
+
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        sizeof = 'bad',
+    })
+    assert.match(err, '["sizeof"] must be a table')
+
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        members = 'bad',
+    })
+    assert.match(err, '["members"] must be a table')
+
+    -- test that throws error if funcs has non-string key
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        funcs = {
+            [1] = {
+                'printf',
+            },
+        },
+    })
+    assert.match(err, '["funcs"] keys must be string')
+
+    -- test that throws error if headers has non-integer key
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        headers = {
+            foo = 'bar',
+        },
+    })
+    assert.match(err, '["headers"] keys must be integer')
+
+    -- test that throws error if funcs[header] value is not a table
+    -- (stdio.h is expected to exist on the test platform)
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        funcs = {
+            ['stdio.h'] = 'bad',
+        },
+    })
+    assert.match(err, 'must be a table')
+
+    -- test that throws error if members[header] value is not a table
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        members = {
+            ['stdio.h'] = 'bad',
+        },
+    })
+    assert.match(err, 'must be a table')
+
+    -- test that throws error if members[header][type] value is not a table
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = 'x',
+        members = {
+            ['stdio.h'] = {
+                ['FILE'] = 'bad',
+            },
+        },
+    })
+    assert.match(err, 'must be a table')
+end
+
+function testcase.generate()
+    -- test that generate produces config.h with expected macros
+    local report, err = generate({
+        cc = 'gcc',
+        output = './test_config.h',
+        features = {
+            '_GNU_SOURCE',
+            _FILE_OFFSET_BITS = '64',
+        },
+        headers = {
+            'stdio.h',
+        },
+        funcs = {
+            ['stdio.h'] = {
+                'printf',
+            },
+        },
+        sizeof = {
+            ['stddef.h'] = {
+                'size_t',
+            },
+        },
+    })
+    assert.not_nil(report)
+    assert.is_nil(err)
+    local f = assert(io.open('./test_config.h', 'r'))
+    os.remove('./test_config.h')
+    local content = f:read('*a')
+    f:close()
+    assert.match(content, '\n#define _GNU_SOURCE\n')
+    assert.match(content, '\n#define _FILE_OFFSET_BITS 64\n')
+    assert.match(content, '\n#define HAVE_STDIO_H 1\n')
+    assert.match(content, '\n#define HAVE_PRINTF 1\n')
+    assert.match(content, '#define SIZEOF_SIZE_T ')
+
+    -- test that a missing header causes its child probes to be skipped
+    report, err = generate({
+        cc = 'gcc',
+        output = './test_config.h',
+        funcs = {
+            ['no_such_header_xyz.h'] = {
+                'some_func_xyz',
+            },
+        },
+    })
+    assert.not_nil(report)
+    assert.is_nil(err)
+    f = assert(io.open('./test_config.h', 'r'))
+    os.remove('./test_config.h')
+    content = f:read('*a')
+    f:close()
+    assert.match(content, 'HAVE_NO_SUCH_HEADER_XYZ_H')
+    assert.is_nil(content:match('HAVE_SOME_FUNC_XYZ'))
+
+    -- test that flush failure returns (nil, err)
+    report, err = generate({
+        cc = 'gcc',
+        output = './nonexistent_dir_xyz/test_config.h',
+        headers = {
+            'stdio.h',
+        },
+    })
+    assert.is_nil(report)
+    assert.match(err, 'No such file or directory')
+
+    -- test that label appears in error messages
+    err = assert.throws(generate, {
+        output = 'x',
+        features = 'bad',
+    }, 'build.modules.mymod')
+    assert.match(err, 'build.modules.mymod["features"] must be a table')
+end
+
+function testcase.generate_report()
+    -- test that report has header entries with is_exists
+    local report, err = generate({
+        cc = 'gcc',
+        output = './test_config.h',
+        headers = {'stdio.h'},
+        funcs = {
+            ['stdio.h'] = {'printf'},
+        },
+        types = {
+            ['sys/types.h'] = {'pid_t'},
+        },
+        decls = {
+            ['unistd.h'] = {'STDIN_FILENO'},
+        },
+        sizeof = {
+            ['stddef.h'] = {'size_t'},
+        },
+        members = {
+            ['stdio.h'] = {
+                FILE = {'_flags'},
+            },
+        },
+    })
+    os.remove('./test_config.h')
+    assert.not_nil(report)
+    assert.is_nil(err)
+
+    -- header in headers[] has is_exists entry
+    assert.is_true(report['stdio.h'].is_exists)
+
+    -- funcs child entry under its header
+    assert.is_true(report['stdio.h']['printf'])
+
+    -- types child entry
+    assert.not_nil(report['sys/types.h'])
+    assert.is_true(report['sys/types.h'].is_exists)
+    assert.is_true(report['sys/types.h']['pid_t'])
+
+    -- decls child entry
+    assert.not_nil(report['unistd.h'])
+    assert.is_true(report['unistd.h'].is_exists)
+    assert.is_true(report['unistd.h']['STDIN_FILENO'])
+
+    -- sizeof child entry
+    assert.not_nil(report['stddef.h'])
+    assert.is_true(report['stddef.h'].is_exists)
+    -- sizeof child entry is the byte size (integer), not a boolean
+    assert.is_true(type(report['stddef.h']['size_t']) == 'number')
+    assert.is_true(report['stddef.h']['size_t'] > 0)
+
+    -- members child entry uses "type.member" key
+    assert.is_true(report['stdio.h']['FILE._flags'])
+
+    -- test that missing header has is_exists=false and no child entries
+    report, err = generate({
+        cc = 'gcc',
+        output = './test_config.h',
+        funcs = {
+            ['no_such_header_xyz.h'] = {'some_func_xyz'},
+        },
+    })
+    os.remove('./test_config.h')
+    assert.not_nil(report)
+    assert.is_nil(err)
+    assert.is_false(report['no_such_header_xyz.h'].is_exists)
+    assert.is_nil(report['no_such_header_xyz.h']['some_func_xyz'])
+
+    -- test that a header appearing in both headers[] and funcs{} gets one entry
+    report = generate({
+        cc = 'gcc',
+        output = './test_config.h',
+        headers = {'stdio.h'},
+        funcs = {
+            ['stdio.h'] = {'printf'},
+        },
+    })
+    os.remove('./test_config.h')
+    assert.not_nil(report)
+    -- count keys in report['stdio.h']: is_exists + printf only (no duplicate)
+    local count = 0
+    for _ in pairs(report['stdio.h']) do count = count + 1 end
+    -- is_exists + printf = 2
+    assert.equal(count, 2)
+end

--- a/test/sortiter_test.lua
+++ b/test/sortiter_test.lua
@@ -1,0 +1,187 @@
+require('luacov')
+local testcase = require('testcase')
+local assert = require('assert')
+local sort = require('configh.sortiter')
+
+-- helper: collect all (k, v) pairs from a stateful closure iterator
+local function collect(iter)
+    local result = {}
+    local k, v = iter()
+    while k ~= nil do
+        result[#result + 1] = {
+            k,
+            v,
+        }
+        k, v = iter()
+    end
+    return result
+end
+
+-- kpairs -----------------------------------------------------------------
+
+function testcase.kpairs_returns_string_keys_sorted()
+    local tbl = {
+        foo = {
+            c = 1,
+            a = 2,
+            b = 3,
+        },
+    }
+    local result = collect(sort.kpairs('root', tbl, 'foo'))
+    assert.equal(#result, 3)
+    assert.equal(result[1][1], 'a')
+    assert.equal(result[2][1], 'b')
+    assert.equal(result[3][1], 'c')
+end
+
+function testcase.kpairs_returns_empty_iter_when_field_is_nil()
+    local tbl = {}
+    local result = collect(sort.kpairs('root', tbl, 'missing'))
+    assert.equal(#result, 0)
+end
+
+function testcase.kpairs_errors_when_field_is_not_table()
+    local err = assert.throws(sort.kpairs, 'root', {
+        foo = 'bad',
+    }, 'foo')
+    assert.match(err, 'root["foo"] must be a table')
+end
+
+function testcase.kpairs_errors_on_non_string_key()
+    local err = assert.throws(sort.kpairs, 'root', {
+        foo = {
+            [1] = 'x',
+        },
+    }, 'foo')
+    assert.match(err, 'keys must be string')
+end
+
+function testcase.kpairs_traverses_nested_path()
+    local tbl = {
+        a = {
+            b = {
+                z = 1,
+                y = 2,
+            },
+        },
+    }
+    local result = collect(sort.kpairs('root', tbl, 'a', 'b'))
+    assert.equal(#result, 2)
+    assert.equal(result[1][1], 'y')
+    assert.equal(result[2][1], 'z')
+end
+
+function testcase.kpairs_errors_on_intermediate_non_table()
+    local err = assert.throws(sort.kpairs, 'root', {
+        a = {
+            b = 'bad',
+        },
+    }, 'a', 'b', 'c')
+    assert.match(err, 'root["a"]["b"] must be a table')
+end
+
+function testcase.kpairs_returns_empty_iter_when_intermediate_is_nil()
+    local tbl = {
+        a = {},
+    }
+    local result = collect(sort.kpairs('root', tbl, 'a', 'missing', 'c'))
+    assert.equal(#result, 0)
+end
+
+-- ipairs -----------------------------------------------------------------
+
+function testcase.ipairs_returns_integer_keys_in_order()
+    local tbl = {
+        arr = {
+            'c',
+            'a',
+            'b',
+        },
+    }
+    local result = collect(sort.ipairs('root', tbl, 'arr'))
+    assert.equal(#result, 3)
+    assert.equal(result[1][2], 'c')
+    assert.equal(result[2][2], 'a')
+    assert.equal(result[3][2], 'b')
+end
+
+function testcase.ipairs_returns_empty_iter_when_field_is_nil()
+    local tbl = {}
+    local result = collect(sort.ipairs('root', tbl, 'missing'))
+    assert.equal(#result, 0)
+end
+
+function testcase.ipairs_errors_when_field_is_not_table()
+    local err = assert.throws(sort.ipairs, 'root', {
+        arr = 'bad',
+    }, 'arr')
+    assert.match(err, 'root["arr"] must be a table')
+end
+
+function testcase.ipairs_errors_on_non_integer_key()
+    local err = assert.throws(sort.ipairs, 'root', {
+        arr = {
+            foo = 'x',
+        },
+    }, 'arr')
+    assert.match(err, 'keys must be integer')
+end
+
+function testcase.ipairs_errors_on_float_key()
+    local err = assert.throws(sort.ipairs, 'root', {
+        arr = {
+            [1.5] = 'x',
+        },
+    }, 'arr')
+    assert.match(err, 'keys must be integer')
+end
+
+-- pairs ------------------------------------------------------------------
+
+function testcase.pairs_returns_string_keys_then_integer_keys()
+    local tbl = {
+        mixed = {
+            [2] = 'two',
+            z = 'z',
+            [1] = 'one',
+            a = 'a',
+        },
+    }
+    local result = collect(sort.pairs('root', tbl, 'mixed'))
+    -- string keys first (sorted), then integer keys (sorted)
+    assert.equal(result[1][1], 'a')
+    assert.equal(result[2][1], 'z')
+    assert.equal(result[3][1], 1)
+    assert.equal(result[4][1], 2)
+end
+
+function testcase.pairs_returns_empty_iter_when_field_is_nil()
+    local tbl = {}
+    local result = collect(sort.pairs('root', tbl, 'missing'))
+    assert.equal(#result, 0)
+end
+
+function testcase.pairs_errors_when_field_is_not_table()
+    local err = assert.throws(sort.pairs, 'root', {
+        mixed = 'bad',
+    }, 'mixed')
+    assert.match(err, 'root["mixed"] must be a table')
+end
+
+function testcase.pairs_errors_on_invalid_key_type()
+    local err = assert.throws(sort.pairs, 'root', {
+        mixed = {
+            [true] = 'x',
+        },
+    }, 'mixed')
+    assert.match(err, 'keys must be string or integer')
+end
+
+function testcase.pairs_errors_on_float_key()
+    local err = assert.throws(sort.pairs, 'root', {
+        mixed = {
+            [1.5] = 'x',
+        },
+    }, 'mixed')
+    assert.match(err, 'keys must be string or integer')
+end


### PR DESCRIPTION
This pull request introduces a new high-level, declarative API for generating `config.h` files in a single call, along with documentation updates and improvements to the return values of several probing methods. The changes make it easier to use the library for common configuration scenarios, improve type safety and reporting in the API, and document these improvements thoroughly.

**New High-level API and Documentation:**

* Added a new `configh.generate` module (`lib/generate.lua`) that provides a `generate()` function for declarative, one-shot configuration generation. This function accepts a table of configuration options, runs all requested probes, writes the output, and returns a structured report. The new API is documented in detail in the `README.md`. [[1]](diffhunk://#diff-e00f6bd43331a10263e1a3e711edca77743d105e2f52ee429d9ff6eb2b56c416R1-R252) [[2]](diffhunk://#diff-030b6cdc19ece93e7680ef5791dde5f589f076325937767145efe2c5f230dbdaR8-R9) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L219-R292) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R371-R431)

**API Improvements:**

* The `check_sizeof` method now returns the size as a third return value (`ok, err, size`), and the README and code have been updated to reflect this. [[1]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L356-R356) [[2]](diffhunk://#diff-7a3059aee345ed2fe29274e6624262f96076f57b3c21e2b29ed7b7ac3f6c6861L433-R438) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L281-R358) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L550-R688) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L565-R701)
* All probe methods (`check_header`, `check_func`, `check_type`, `check_decl`, `check_member`, `check_sizeof`, and `flush`) now consistently return `err` as an optional value (`string?`), improving error handling and documentation clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L488-R623) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L504-R639) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L519-R654) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L534-R669) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L550-R688) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L585-R721)

**Internal/Supporting Changes:**

* The `.luacov` module table is updated to include the new `configh.generate` and `configh.sortiter` modules.

These changes collectively provide a more user-friendly and robust interface for generating configuration headers, while maintaining backward compatibility with the lower-level instance API.