### PR TITLE
Add stdout parameter to generate() for probe output redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ end
 ```
 
 
-## report, err = generate( cfg [, label] )
+## report, err = generate( cfg [, label [, stdout]] )
 
 `require('configh.generate')` returns this function.
 
@@ -404,6 +404,9 @@ entry point when all probe information is known up front.
 - `label:string?`: root label used in error messages (default: `'cfg'`).
   Typically set to the module name (e.g. `build.modules` key) when called
   from `luarocks-build-hooks`.
+- `stdout:file*?`: file handle for probe status output (default: `io.stdout`).
+  Overrides the handle used by `configh:set_stdout()` inside the call.
+  Has effect only when `output_status` is `true`.
 
 **Returns**
 

--- a/lib/generate.lua
+++ b/lib/generate.lua
@@ -173,9 +173,10 @@ end
 --- and flushes the result to cfg.output.
 --- @param cfg table
 --- @param label string?  root label for error messages (default: 'cfg')
+--- @param stdout file*?  file handle for probe status output (default: io.stdout)
 --- @return table? report
 --- @return string? err
-local function generate(cfg, label)
+local function generate(cfg, label, stdout)
     label = label or 'cfg'
     assert(type(label) == 'string', 'label must be a string')
     assert(type(cfg) == 'table', label .. ' must be a table')
@@ -201,6 +202,9 @@ local function generate(cfg, label)
 
     local cfgh = configh(cfg.cc)
 
+    if stdout ~= nil then
+        cfgh:set_stdout(stdout)
+    end
     if cfg.output_status ~= nil then
         cfgh:output_status(cfg.output_status)
     end

--- a/test/generate_test.lua
+++ b/test/generate_test.lua
@@ -212,27 +212,69 @@ function testcase.generate()
     assert.match(err, 'build.modules.mymod["features"] must be a table')
 end
 
+function testcase.generate_with_stdout()
+    -- test that stdout argument is forwarded to cfgh:set_stdout()
+    local tmpfile = os.tmpname()
+    local f = assert(io.open(tmpfile, 'w'))
+    local report, err = generate({
+        cc = 'gcc',
+        output = './test_config.h',
+        output_status = true,
+        headers = {
+            'stdio.h',
+        },
+    }, nil, f)
+    f:close()
+    os.remove('./test_config.h')
+    assert.not_nil(report)
+    assert.is_nil(err)
+    local rf = assert(io.open(tmpfile, 'r'))
+    local content = rf:read('*a')
+    rf:close()
+    os.remove(tmpfile)
+    assert.match(content, 'stdio.h')
+
+    -- test that an invalid stdout type raises error
+    err = assert.throws(generate, {
+        cc = 'gcc',
+        output = './test_config.h',
+    }, nil, 'not a file')
+    assert.match(err, 'outfile must be file or nil')
+end
+
 function testcase.generate_report()
     -- test that report has header entries with is_exists
     local report, err = generate({
         cc = 'gcc',
         output = './test_config.h',
-        headers = {'stdio.h'},
+        headers = {
+            'stdio.h',
+        },
         funcs = {
-            ['stdio.h'] = {'printf'},
+            ['stdio.h'] = {
+                'printf',
+            },
         },
         types = {
-            ['sys/types.h'] = {'pid_t'},
+            ['sys/types.h'] = {
+                'pid_t',
+            },
         },
         decls = {
-            ['unistd.h'] = {'STDIN_FILENO'},
+            ['unistd.h'] = {
+                'STDIN_FILENO',
+            },
         },
         sizeof = {
-            ['stddef.h'] = {'size_t'},
+            ['stddef.h'] = {
+                'size_t',
+            },
         },
         members = {
             ['stdio.h'] = {
-                FILE = {'_flags'},
+                FILE = {
+                    '_flags',
+                },
             },
         },
     })
@@ -271,7 +313,9 @@ function testcase.generate_report()
         cc = 'gcc',
         output = './test_config.h',
         funcs = {
-            ['no_such_header_xyz.h'] = {'some_func_xyz'},
+            ['no_such_header_xyz.h'] = {
+                'some_func_xyz',
+            },
         },
     })
     os.remove('./test_config.h')
@@ -284,16 +328,22 @@ function testcase.generate_report()
     report = generate({
         cc = 'gcc',
         output = './test_config.h',
-        headers = {'stdio.h'},
+        headers = {
+            'stdio.h',
+        },
         funcs = {
-            ['stdio.h'] = {'printf'},
+            ['stdio.h'] = {
+                'printf',
+            },
         },
     })
     os.remove('./test_config.h')
     assert.not_nil(report)
     -- count keys in report['stdio.h']: is_exists + printf only (no duplicate)
     local count = 0
-    for _ in pairs(report['stdio.h']) do count = count + 1 end
+    for _ in pairs(report['stdio.h']) do
+        count = count + 1
+    end
     -- is_exists + printf = 2
     assert.equal(count, 2)
 end


### PR DESCRIPTION
This pull request adds support for specifying a custom output file handle for probe status output in the `generate` function, updates documentation to reflect the new parameter, and adds comprehensive tests for this feature. The most important changes are grouped below.

**Feature enhancement:**

* Added a new optional `stdout` parameter to the `generate` function in `lib/generate.lua`, allowing callers to specify a file handle for probe status output instead of using the default `io.stdout`. The function now forwards this parameter to `cfgh:set_stdout(stdout)` if provided. [[1]](diffhunk://#diff-e00f6bd43331a10263e1a3e711edca77743d105e2f52ee429d9ff6eb2b56c416R176-R179) [[2]](diffhunk://#diff-e00f6bd43331a10263e1a3e711edca77743d105e2f52ee429d9ff6eb2b56c416R205-R207)

**Documentation updates:**

* Updated the `README.md` to document the new `stdout` parameter for the `generate` function, including its purpose and usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L371-R371) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R407-R409)

**Testing improvements:**

* Added a new test case `generate_with_stdout` in `test/generate_test.lua` to verify that the `stdout` argument is correctly handled, including tests for both valid and invalid file handle types.

**Test refactoring:**

* Refactored and reformatted existing tests in `test/generate_test.lua` for better readability and consistency, including expanding table entries to multiple lines. [[1]](diffhunk://#diff-4f485e6546d351f9e9d59c6aa09a1a9cbc8db265fb1194ff7a154ed688902780L274-R318) [[2]](diffhunk://#diff-4f485e6546d351f9e9d59c6aa09a1a9cbc8db265fb1194ff7a154ed688902780L287-R346)