### PR TITLE
Fix cc validation in Executor:init()

### DIFF
--- a/lib/executor.lua
+++ b/lib/executor.lua
@@ -75,6 +75,12 @@ function Executor:init(cc)
         error('cc must be string or nil')
     end
 
+    -- trim whitespace
+    cc = cc:match('^%s*(.-)%s*$')
+    if not cc:find('^[a-zA-Z]') then
+        error('cc must start with an ASCII letter')
+    end
+
     self.cc = cc
     self.features = {}
     self.cppflags = {}

--- a/test/executor_test.lua
+++ b/test/executor_test.lua
@@ -38,6 +38,18 @@ function testcase.new_executor()
     err = assert.throws(executor)
     assert.match(err,
                  'cc argument or CC environment variable must contain compiler name')
+
+    -- test that throws an error if cc is empty or whitespace-only
+    err = assert.throws(executor, '')
+    assert.match(err, 'cc must start with an ASCII letter')
+    err = assert.throws(executor, '   ')
+    assert.match(err, 'cc must start with an ASCII letter')
+
+    -- test that throws an error if cc does not start with a letter
+    err = assert.throws(executor, '123gcc')
+    assert.match(err, 'cc must start with an ASCII letter')
+    err = assert.throws(executor, '/usr/bin/cc')
+    assert.match(err, 'cc must start with an ASCII letter')
 end
 
 function testcase.makecsrc()


### PR DESCRIPTION
This pull request enhances validation for the `cc` (compiler name) argument in the `Executor` class and adds corresponding tests to ensure robust error handling for invalid inputs.

**Validation improvements for `cc` argument:**

* [`lib/executor.lua`](diffhunk://#diff-0f9b6bb3554ae632e3921dad35124789dda52b237e5bbd11d1129cfa822987f3R78-R83): Added logic to trim whitespace from the `cc` argument and ensure it starts with an ASCII letter, raising an error otherwise.

**Test coverage:**

* [`test/executor_test.lua`](diffhunk://#diff-96fd44eb1c4465765b80b9d5f3a8b02d38516f96f1ee24c33cd1af462fceced0R41-R52): Added tests to verify that errors are raised if `cc` is empty, contains only whitespace, or does not start with an ASCII letter (e.g., starts with a number or slash).